### PR TITLE
8.1.4

### DIFF
--- a/includes/admin-pages/meta-fields/page-meta-fields-add-update.php
+++ b/includes/admin-pages/meta-fields/page-meta-fields-add-update.php
@@ -131,7 +131,7 @@
                                                     <label for="field_name"><?php echo __('Field / Question', WE_LS_SLUG); ?></label>
                                                 </div>
                                                 <div class="ws-ls-cell">
-                                                    <input type="text" name="field_name" id="field_name" class="<?php if ( true === $validation_fail && true === empty( $meta_field['field_name'] ) ) { echo 'ws-ls-mandatory-field'; } ?>"  size="40" maxlength="40" value="<?php echo ( false === empty( $meta_field['field_name'] ) ) ? esc_attr( $meta_field['field_name'] ) : ''; ?>"/><span class="ws-ls-mandatory">*</span>
+                                                    <input type="text" name="field_name" id="field_name" class="<?php if ( true === $validation_fail && true === empty( $meta_field['field_name'] ) ) { echo 'ws-ls-mandatory-field'; } ?>"  size="40" maxlength="200" value="<?php echo ( false === empty( $meta_field['field_name'] ) ) ? esc_attr( $meta_field['field_name'] ) : ''; ?>"/><span class="ws-ls-mandatory">*</span>
                                                 </div>
                                             </div>
                                             <div class="ws-ls-row">

--- a/includes/admin-pages/settings/page-settings-generic.php
+++ b/includes/admin-pages/settings/page-settings-generic.php
@@ -748,6 +748,26 @@ function ws_ls_settings_page_generic() {
                                                 </tr>
 												<tr>
 													<th colspan="2">
+														<h3><?php echo __( 'Custom Field Options', WE_LS_SLUG ); ?></h3>
+													</th>
+												</tr>
+												<tr  class="<?php echo $disable_if_not_pro_class; ?>">
+													<th scope="row"><?php echo __( 'Field / Question or Abbreviation', WE_LS_SLUG ); ?></th>
+													<td>
+														<?php
+
+														$abbv_or_question = get_option( 'ws-ls-abbv-or-question', 'abbv' );
+
+														?>
+														<select id="ws-ls-abbv-or-question" name="ws-ls-abbv-or-question">
+															<option value="abbv" <?php selected( $abbv_or_question, 'abbv' ); ?>><?php echo __( 'Abbreviation', WE_LS_SLUG ); ?></option>
+															<option value="question" <?php selected( $abbv_or_question, 'question' ); ?>><?php echo __( 'Field / Question', WE_LS_SLUG ); ?></option>
+														</select>
+														<p><?php echo __('When displaying a custom field on a chart, which value should be displayed in the chart\`s legend? The field question or abbreviation.', WE_LS_SLUG); ?></p>
+													</td>
+												</tr>
+												<tr>
+													<th colspan="2">
 														<h3><?php echo __( 'Line Chart Options', WE_LS_SLUG ); ?></h3>
 													</th>
 												</tr>
@@ -1037,6 +1057,7 @@ function ws_ls_register_settings(){
         register_setting( 'we-ls-options-group', 'ws-ls-chart-type' );
         register_setting( 'we-ls-options-group', 'ws-ls-max-points' );
         register_setting( 'we-ls-options-group', 'ws-ls-bezier-curve' );
+		register_setting( 'we-ls-options-group', 'ws-ls-abbv-or-question' );
         register_setting( 'we-ls-options-group', 'ws-ls-point-size' );
         register_setting( 'we-ls-options-group', 'ws-ls-grid-lines' );
 

--- a/includes/core-charting.php
+++ b/includes/core-charting.php
@@ -197,6 +197,10 @@ function ws_ls_display_chart( $weight_data, $options = [] ) {
 		return ! empty( $dataset['data'] );
 	} );
 
+	// If we strip a meta field out due to above, then we may have a missing array index e.g. 0,1,2,3,5, we need this line to
+	// reshuffle and allow the chart to render.
+	$graph_data['datasets'] = array_values($graph_data['datasets']);
+
 	ws_ls_charting_enqueue_scripts();
 
 	// Embed JavaScript data object for this graph into page

--- a/includes/core-charting.php
+++ b/includes/core-charting.php
@@ -131,14 +131,18 @@ function ws_ls_display_chart( $weight_data, $options = [] ) {
 
 		$meta_dataset_index = $chart_config[ 'min-datasets' ]; // Determine data set on whether or not a target weight has been displayed
 
+		$use_abbreviation = ( 'abbv' === get_option( 'ws-ls-abbv-or-question', 'abbv' ) );
+
 		for( $i = 0; $i < count( $chart_config[ 'meta-fields' ] ); $i++ ) {
 
 			$chart_config[ 'meta-fields' ][ $i ][ 'index' ] = $meta_dataset_index;
 
 			$field = $chart_config[ 'meta-fields' ][ $i ];
 
+			$meta_label =
+
 			$graph_data['datasets'][ $meta_dataset_index ] = [
-																'label'             => $field[ 'field_name' ],
+																'label'             => ( $use_abbreviation ) ? $field[ 'abv' ] : $field[ 'field_name' ],
 																'borderColor'       => $field[ 'plot_colour' ],
 																'borderWidth'       => $chart_config[ 'line-thickness' ],
 																'pointRadius'       => $chart_config[ 'point-size' ],

--- a/pro-features/email-notifications.php
+++ b/pro-features/email-notifications.php
@@ -121,6 +121,13 @@ function ws_ls_email_user_summary( $user_id ) {
 
 	$summary = sprintf('<h4>%s</h4>', __( 'Weight Summary', WE_LS_SLUG ) );
 
+	$current_user = get_userdata( $user_id );
+
+	if ( false === empty( $current_user->user_email ) ) {
+		$summary .= sprintf( '<h5>%s</h5>', __( 'User email address', WE_LS_SLUG ) );
+		$summary .= sprintf( '<p><a href="mailto:%1$s>%1$s</a></p>', esc_html( $current_user->user_email ) );
+	}
+
 	$latest_entry = ws_ls_entry_get_latest( [ 'user-id' => $user_id, 'meta' => false ] );
 
 	if ( false === empty( $latest_entry ) ) {

--- a/pro-features/plus/meta-fields/activate.php
+++ b/pro-features/plus/meta-fields/activate.php
@@ -21,7 +21,7 @@
         $sql = "CREATE TABLE $table_name (
                 id mediumint(9) NOT NULL AUTO_INCREMENT,
                 field_key varchar(40) NOT NULL,
-                field_name varchar(40) NOT NULL,
+                field_name varchar(200) NOT NULL,
                 abv varchar(5) NOT NULL,
                 suffix varchar(10) NOT NULL,
                 mandatory int DEFAULT 1,

--- a/readme.txt
+++ b/readme.txt
@@ -160,6 +160,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 = 8.1.4 =
 
+* Improvement: Custom field names / questions have been increased from 40 characted to 200 to allow for bigger questions.
 * Bug fix: When a meta field was removed from the graph dataset due to no data, a missing index caused the graph to fail. This has now been corrected.
 
 = 8.1.3 =

--- a/readme.txt
+++ b/readme.txt
@@ -160,7 +160,8 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 = 8.1.4 =
 
-* Improvement: Custom field names / questions have been increased from 40 characted to 200 to allow for bigger questions.
+* Improvement: Custom field names / questions have been increased from 40 characters to 200 to allow for bigger questions.
+* Improvement: New setting: Specify whether to use a custom field's name / question or abbreviation for chart legends.
 * Bug fix: When a meta field was removed from the graph dataset due to no data, a missing index caused the graph to fail. This has now been corrected.
 
 = 8.1.3 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aliakro
 Tags: weight, loss, lose, tracker, bmi, bmr, macronutrient, graph, chart, track, stones, kg, table, calories, awards, email, custom, fields, history, pounds, responsive, chart, measurements, cm, centimeters, inches, photos
 Requires at least: 4.4.9
 Tested up to: 5.5.1
-Stable tag: 8.1.3
+Stable tag: 8.1.4
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -157,6 +157,10 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 8.1 - A new and improved export tool that handles large data sets!
 
 == Changelog ==
+
+= 8.1.4 =
+
+* Bug fix: When a meta field was removed from the graph dataset due to no data, a missing index caused the graph to fail. This has now been corrected.
 
 = 8.1.3 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 * Improvement: Custom field names / questions have been increased from 40 characters to 200 to allow for bigger questions.
 * Improvement: New setting: Specify whether to use a custom field's name / question or abbreviation for chart legends.
+* Improvement: Added user's email address to email notifications.
 * Bug fix: When a meta field was removed from the graph dataset due to no data, a missing index caused the graph to fail. This has now been corrected.
 
 = 8.1.3 =

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die('Jog on!');
 /**
  * Plugin Name:         Weight Tracker
  * Description:         Allow your users to track their weight, body measurements, photos and other pieces of custom data. Display in charts, tables, shortcodes and widgets. Manage their data, issue awards, email notifications, etc! Provide advanced data on Body Mass Index (BMI), Basal Metabolic Rate (BMR), Calorie intake, Harris Benedict Formula, Macronutrients Calculator and more.
- * Version:             8.1.3
+ * Version:             8.1.4
  * Requires at least:   5.2
  * Requires PHP:        7.2
  * Author:              Ali Colville
@@ -17,7 +17,7 @@ defined('ABSPATH') or die('Jog on!');
  */
 
 define( 'WS_LS_ABSPATH', plugin_dir_path( __FILE__ ) );
-define( 'WE_LS_CURRENT_VERSION', '8.1.2' );
+define( 'WE_LS_CURRENT_VERSION', '8.1.4' );
 define( 'WE_LS_DB_VERSION', '8.1' );
 define( 'WE_LS_TITLE', 'Weight Tracker' );
 define( 'WE_LS_SLUG', 'weight-loss-tracker' );

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -18,7 +18,7 @@ defined('ABSPATH') or die('Jog on!');
 
 define( 'WS_LS_ABSPATH', plugin_dir_path( __FILE__ ) );
 define( 'WE_LS_CURRENT_VERSION', '8.1.4' );
-define( 'WE_LS_DB_VERSION', '8.1' );
+define( 'WE_LS_DB_VERSION', '8.1.4' );
 define( 'WE_LS_TITLE', 'Weight Tracker' );
 define( 'WE_LS_SLUG', 'weight-loss-tracker' );
 define( 'WE_LS_LICENSE_TYPES_URL', 'https://weight.yeken.uk/features' );


### PR DESCRIPTION
* Improvement: Custom field names / questions have been increased from 40 characters to 200 to allow for bigger questions.
* Improvement: New setting: Specify whether to use a custom field's name / question or abbreviation for chart legends.
* Improvement: Added user's email address to email notifications.
* Bug fix: When a meta field was removed from the graph dataset due to no data, a missing index caused the graph to fail. This has now been corrected.
