### PR TITLE
8.1.5

### DIFF
--- a/includes/admin-pages/settings/page-settings-generic.php
+++ b/includes/admin-pages/settings/page-settings-generic.php
@@ -682,7 +682,7 @@ function ws_ls_settings_page_generic() {
 														<td>
 															<?php
 
-																$chart_options  = [ 5, 10, 25, 50, 100 ,200 ];
+																$chart_options  = [ 5, 10, 25, 50, 100, 200 ];
 																$max_points     = get_option( 'ws-ls-max-points', '25' );
 															?>
 															<select id="ws-ls-max-points" name="ws-ls-max-points">
@@ -940,6 +940,19 @@ function ws_ls_settings_page_generic() {
 														</td>
 													</tr>
 													<tr class="<?php echo $disable_if_not_pro_class; ?>">
+														<th scope="row"><?php echo __( 'Include User\'s email address?', WE_LS_SLUG ); ?></th>
+														<td>
+															<?php
+															$include_email_address = get_option( 'ws-ls-email-include-email-address', 'yes' );
+															?>
+															<select id="ws-ls-email-include-email-address" name="ws-ls-email-include-email-address">
+																<option value="yes" <?php selected( $include_email_address, 'yes' ); ?>><?php echo __('Yes', WE_LS_SLUG)?></option>
+																<option value="no" <?php selected( $include_email_address, 'no' ); ?>><?php echo __('No', WE_LS_SLUG)?></option>
+															</select>
+															<p><?php echo __('Receive notifications when a member edits an existing weight / custom field entry.', WE_LS_SLUG); ?></p>
+														</td>
+													</tr>
+													<tr class="<?php echo $disable_if_not_pro_class; ?>">
 														<th scope="row"><?php echo __( 'Include Weight Summary?', WE_LS_SLUG ); ?></th>
 														<td>
 															<?php
@@ -949,7 +962,7 @@ function ws_ls_settings_page_generic() {
 																<option value="yes" <?php selected( $include_weight_summary, 'yes' ); ?>><?php echo __('Yes', WE_LS_SLUG)?></option>
 																<option value="no" <?php selected( $include_weight_summary, 'no' ); ?>><?php echo __('No', WE_LS_SLUG)?></option>
 															</select>
-															<p><?php echo __('Receive notifications when a member edits an existing weight / custom field entry.', WE_LS_SLUG); ?></p>
+															<p><?php echo __('Add additional weight summary information into the email e.g. start weight, previous weight, difference between both, difference between current weight and start weight, etc.', WE_LS_SLUG); ?></p>
 														</td>
 													</tr>
 												</table>
@@ -1084,6 +1097,7 @@ function ws_ls_register_settings(){
 		register_setting( 'we-ls-options-group', 'ws-ls-email-notifications-new' );
 		register_setting( 'we-ls-options-group', 'ws-ls-email-notifications-targets' );
 		register_setting( 'we-ls-options-group', 'ws-ls-email-include-weight-summary' );
+		register_setting( 'we-ls-options-group', 'ws-ls-email-include-email-address' );
 
 		// Third Party
         register_setting( 'we-ls-options-group', 'ws-ls-gf-enable' );

--- a/includes/admin-pages/settings/page-settings-generic.php
+++ b/includes/admin-pages/settings/page-settings-generic.php
@@ -24,6 +24,10 @@ function ws_ls_settings_page_generic() {
 		ws_ls_cache_delete_all();
 	}
 
+	if ( true === isset( $_GET[ 'settings-updated' ] ) ) {
+		do_action( 'ws_ls_settings_saved' );
+	}
+
 	?>
 	<div class="wrap ws-ls-admin-page">
 

--- a/includes/caching.php
+++ b/includes/caching.php
@@ -4,6 +4,20 @@ defined('ABSPATH') or die("Jog on!");
 define( 'WE_LS_CACHE_ENABLED', 'yes' === get_option( 'ws-ls-caching', 'yes' ) );
 define( 'WE_LS_CACHE_TIME', DAY_IN_SECONDS );
 define( 'WE_LS_CACHE_SHORT_TIME', 5 * MINUTE_IN_SECONDS );
+define( 'WE_LS_INITIAL_CACHE_NUMBER', 1 );
+/**
+ * When settings are saved, invalidate existing cache by incrementing cache version number.
+ */
+function ws_ls_cache_admin_hooks_update_cache_version() {
+
+	$current_version = get_option( 'ws-ls-cache-number', WE_LS_INITIAL_CACHE_NUMBER );
+
+	$current_version++;
+
+	update_option( 'ws-ls-cache-number', $current_version );
+
+}
+add_action( 'ws_ls_settings_saved', 'ws_ls_cache_admin_hooks_update_cache_version');
 
 /**
  * User caching. From now on, store an array for each user in cache. Each caache key can then be stored in an array element.
@@ -233,7 +247,10 @@ function ws_ls_cache_delete_all() {
  * @return string
  */
 function ws_ls_cache_generate_key( $key ){
-    return sprintf( '%s-%s-%s', WE_LS_SLUG, WE_LS_CURRENT_VERSION, $key );
+
+	$cache_version = get_option( 'ws-ls-cache-number', WE_LS_INITIAL_CACHE_NUMBER );
+
+	return sprintf( 'wt-%s-%s-%s-%d-%s',  WS_LS_IS_PRO_PLUS, WS_LS_IS_PRO, WE_LS_CURRENT_VERSION, $cache_version, $key );
 }
 
 /**

--- a/pro-features/email-notifications.php
+++ b/pro-features/email-notifications.php
@@ -92,6 +92,16 @@ function ws_ls_email_notification( $type, $weight_data ) {
 
 		}
 
+		// Add user's email address into email?
+		if ( 'yes' === get_option( 'ws-ls-email-include-email-address', 'yes' ) ) {
+
+			$current_user = get_userdata( $type[ 'user-id' ] );
+
+			if ( false === empty( $current_user->user_email ) ) {
+				$email_data[ 'data' ] .= sprintf('<h4>%s</h4>', __('User email address', WE_LS_SLUG) );
+				$email_data[ 'data' ] .= sprintf('<p><a href="mailto:%1$s>%1$s</a></p>', esc_html( $current_user->user_email ) );
+			}
+		}
 		// Add weight summary
 		if ( 'yes' === get_option( 'ws-ls-email-include-weight-summary', 'yes' ) ) {
 			$email_data[ 'data' ] .= ws_ls_email_user_summary( $type[ 'user-id' ] );
@@ -120,13 +130,6 @@ add_action( 'wlt-hook-data-added-edited', 'ws_ls_email_notification', 10, 2);
 function ws_ls_email_user_summary( $user_id ) {
 
 	$summary = sprintf('<h4>%s</h4>', __( 'Weight Summary', WE_LS_SLUG ) );
-
-	$current_user = get_userdata( $user_id );
-
-	if ( false === empty( $current_user->user_email ) ) {
-		$summary .= sprintf( '<h5>%s</h5>', __( 'User email address', WE_LS_SLUG ) );
-		$summary .= sprintf( '<p><a href="mailto:%1$s>%1$s</a></p>', esc_html( $current_user->user_email ) );
-	}
 
 	$latest_entry = ws_ls_entry_get_latest( [ 'user-id' => $user_id, 'meta' => false ] );
 

--- a/pro-features/plus/photos-gallery.php
+++ b/pro-features/plus/photos-gallery.php
@@ -97,6 +97,13 @@ function ws_ls_photos_shortcode_gallery($user_defined_arguments) {
 
 		foreach ( $photos as $photo ) {
 
+			if ( 'awards' !== $arguments['source'] ) {
+				$weight = ws_ls_weight_display( $photo[ 'kg' ], $arguments['user-id'] );
+				$date   = ws_ls_convert_ISO_date_into_locale( $photo[ 'weight_date' ] );
+
+				$photo['display-text'] = $date['display-date'] . ' &middot; ' . $photo[ 'field_name' ] . ' &middot; ' . $weight[ 'display' ];
+			}
+
 			$additional_data = sprintf(' alt="%1$s" data-image="%2$s" data-description="%1$s"',
 				esc_html( $photo['display-text'] ),
 				esc_html( $photo['full'] )

--- a/readme.txt
+++ b/readme.txt
@@ -160,6 +160,8 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 = 8.1.5 =
 
+* Improvement: New setting to disable adding user's email to notification settings.
+* Bug fix: Corrected rendering of user email address in notification email (i.e. not part of Weight Summary).
 * Bug fix: Fixed issue when rendering [wt-gallery] where an error would be displayed saying an array element was missing.
 
 = 8.1.4 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aliakro
 Tags: weight, loss, lose, tracker, bmi, bmr, macronutrient, graph, chart, track, stones, kg, table, calories, awards, email, custom, fields, history, pounds, responsive, chart, measurements, cm, centimeters, inches, photos
 Requires at least: 4.4.9
 Tested up to: 5.5.1
-Stable tag: 8.1.4
+Stable tag: 8.1.5
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -157,6 +157,10 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 8.1 - A new and improved export tool that handles large data sets!
 
 == Changelog ==
+
+= 8.1.5 =
+
+* Bug fix: Fixed issue when rendering [wt-gallery] where an error would be displayed saying an array element was missing.
 
 = 8.1.4 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -161,6 +161,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 = 8.1.5 =
 
 * Improvement: New setting to disable adding user's email to notification settings.
+* Improvement: Entire cache is invalidated when settings are saved.
 * Bug fix: Corrected rendering of user email address in notification email (i.e. not part of Weight Summary).
 * Bug fix: Fixed issue when rendering [wt-gallery] where an error would be displayed saying an array element was missing.
 

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die('Jog on!');
 /**
  * Plugin Name:         Weight Tracker
  * Description:         Allow your users to track their weight, body measurements, photos and other pieces of custom data. Display in charts, tables, shortcodes and widgets. Manage their data, issue awards, email notifications, etc! Provide advanced data on Body Mass Index (BMI), Basal Metabolic Rate (BMR), Calorie intake, Harris Benedict Formula, Macronutrients Calculator and more.
- * Version:             8.1.4
+ * Version:             8.1.5
  * Requires at least:   5.2
  * Requires PHP:        7.2
  * Author:              Ali Colville
@@ -17,7 +17,7 @@ defined('ABSPATH') or die('Jog on!');
  */
 
 define( 'WS_LS_ABSPATH', plugin_dir_path( __FILE__ ) );
-define( 'WE_LS_CURRENT_VERSION', '8.1.4' );
+define( 'WE_LS_CURRENT_VERSION', '8.1.5' );
 define( 'WE_LS_DB_VERSION', '8.1.4' );
 define( 'WE_LS_TITLE', 'Weight Tracker' );
 define( 'WE_LS_SLUG', 'weight-loss-tracker' );


### PR DESCRIPTION
* Improvement: New setting to disable adding user's email to notification settings.
* Improvement: Entire cache is invalidated when settings are saved.
* Bug fix: Corrected rendering of user email address in notification email (i.e. not part of Weight Summary).
* Bug fix: Fixed issue when rendering [wt-gallery] where an error would be displayed saying an array element was missing.