### PR TITLE
10.1.4

### DIFF
--- a/pro-features/user-birthdays.php
+++ b/pro-features/user-birthdays.php
@@ -28,7 +28,7 @@
             if ( false === ws_ls_emailer_get('email-birthday') ) {
 
                 ws_ls_emailer_add( 'email-birthday', 'Happy Birthday!', '<center>
-                                                    <h1>Happy Birthday {name}!</h1>
+                                                    <h1>Happy Birthday {first-name} {last-name}!</h1>
                                                     <p>We thought we\'d drop you a quick message to wish you all the best and hope you have a great day!</p>
                                                     <p>All the best,</p>
                                                     <p><a href="{url}" target="_blank" rel="noopener">{name}</a></p>
@@ -59,7 +59,8 @@
             $current_user = get_userdata( $user_id );
 
             $placeholders = [
-                'name' => ( false === empty( $current_user->user_nicename ) ) ? $current_user->user_nicename : ''
+                'first-name' => ( false === empty( $current_user->first_name ) ) ? $current_user->first_name : '',
+	            'last-name' => ( false === empty( $current_user->last_name ) ) ? $current_user->last_name : ''
             ];
 
             if (false === empty( $current_user->user_email )) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aliakro
 Tags: weight,tracker,chart,bmi,bmr,macronutrient,measure,awards,custom fields,history,measurements,data
 Requires at least: 5.7
 Tested up to: 6.0
-Stable tag: 10.1.3
+Stable tag: 10.1.4
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -148,6 +148,10 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 10.0 - New shortcode! Beta! [wt-beta]
 
 == Changelog ==
+
+= 10.1.4 =
+
+* Bug fix: For birthday emails, {name} has been replaced with {first-name} and {last-name}. These can be used within the email template.
 
 = 10.1.3 =
 

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die('Jog on!');
 /**
  * Plugin Name:         Weight Tracker
  * Description:         Allow your users to track their weight, body measurements, photos and other pieces of custom data. Display in charts, tables, shortcodes and widgets. Manage their data, issue awards, email notifications, etc! Provide advanced data on Body Mass Index (BMI), Basal Metabolic Rate (BMR), Calorie intake, Harris Benedict Formula, Macronutrients Calculator and more.
- * Version:             10.1.3
+ * Version:             10.1.4
  * Requires at least:   5.7
  * Tested up to: 		6.0
  * Requires PHP:        7.2
@@ -18,7 +18,7 @@ defined('ABSPATH') or die('Jog on!');
  */
 
 define( 'WS_LS_ABSPATH', plugin_dir_path( __FILE__ ) );
-define( 'WE_LS_CURRENT_VERSION', '10.1.2' );
+define( 'WE_LS_CURRENT_VERSION', '10.1.4' );
 define( 'WE_LS_TITLE', 'Weight Tracker' );
 define( 'WE_LS_SLUG', 'weight-loss-tracker' );
 define( 'WE_LS_LICENSE_TYPES_URL', 'https://docs.yeken.uk/features.html' );


### PR DESCRIPTION
* Bug fix: For birthday emails, {name} has been replaced with {first-name} and {last-name}. These can be used within the email template.