### PR TITLE
10.2.1

### DIFF
--- a/includes/shortcode-weight-tracker-beta.php
+++ b/includes/shortcode-weight-tracker-beta.php
@@ -176,7 +176,7 @@ function ws_ls_shortcode_wt_kiosk( $user_defined_arguments ) {
 		return ws_ls_display_pro_upgrade_notice_for_shortcode( true );
 	}
 
-	$arguments = shortcode_atts( [ 'kiosk-mode' => true ], $user_defined_arguments );
+	$arguments = wp_parse_args( [ 'kiosk-mode' => true ], $user_defined_arguments );
 
 	return ws_ls_shortcode_beta( $arguments );
 }

--- a/pro-features/user-groups.php
+++ b/pro-features/user-groups.php
@@ -682,6 +682,8 @@ function ws_ls_ajax_groups_users_get(){
 		wp_send_json( $cache );
 	}
 
+	$diff_label = ( true === ws_ls_to_bool( $todays_entries_only ) ) ? __('Diff from start', WE_LS_SLUG) : __('Diff from prev', WE_LS_SLUG);
+
 	$columns = [
 		[ 'name' => 'id', 'title' => __('ID', WE_LS_SLUG), 'breakpoints'=> '', 'type' => 'number', 'visible' => false ],
 		[ 'name' => 'display_name', 'title' => __('User', WE_LS_SLUG), 'breakpoints'=> '', 'type' => 'text' ],
@@ -689,7 +691,7 @@ function ws_ls_ajax_groups_users_get(){
         [ 'name' => 'start-weight', 'title' => __('Start', WE_LS_SLUG), 'breakpoints'=> 'md', 'type' => 'text' ],
 		[ 'name' => 'previous-weight', 'title' => __('Previous', WE_LS_SLUG), 'breakpoints'=> 'md', 'type' => 'text' ],
         [ 'name' => 'latest-weight', 'title' => __('Latest', WE_LS_SLUG), 'breakpoints'=> '', 'type' => 'text' ],
-        [ 'name' => 'diff-weight', 'title' => __('Diff from start', WE_LS_SLUG), 'breakpoints'=> 'md', 'type' => 'text' ],
+        [ 'name' => 'diff-weight', 'title' => $diff_label, 'breakpoints'=> 'md', 'type' => 'text' ],
         [ 'name' => 'target', 'title' => __('Target', WE_LS_SLUG), 'breakpoints'=> '', 'type' => 'text' ],
 		[ 'name' => 'awards', 'title' => __('Awards', WE_LS_SLUG), 'breakpoints'=> 'md', 'type' => 'text' ],
 	];

--- a/readme.txt
+++ b/readme.txt
@@ -153,6 +153,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 = 10.2.1 =
 
 * Bug fix: [wt-kiosk] now passes the arguments correctly to the underlying [wt-beta] shortcode.
+* Bug fix: When showing today's entries for the group, then show the correct label "Diff from start".
 
 = 10.2 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aliakro
 Tags: weight,tracker,chart,bmi,bmr,macronutrient,measure,awards,custom fields,history,measurements,data
 Requires at least: 5.7
 Tested up to: 6.0
-Stable tag: 10.2
+Stable tag: 10.2.1
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -149,6 +149,10 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 10.2 - "Kiosk Mode" for [wt-beta]!
 
 == Changelog ==
+
+= 10.2.1 =
+
+* Bug fix: [wt-kiosk] now passes the arguments correctly to the underlying [wt-beta] shortcode.
 
 = 10.2 =
 

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die('Jog on!');
 /**
  * Plugin Name:         Weight Tracker
  * Description:         Allow your users to track their weight, body measurements, photos and other pieces of custom data. Display in charts, tables, shortcodes and widgets. Manage their data, issue awards, email notifications, etc! Provide advanced data on Body Mass Index (BMI), Basal Metabolic Rate (BMR), Calorie intake, Harris Benedict Formula, Macronutrients Calculator and more.
- * Version:             10.2
+ * Version:             10.2.1
  * Requires at least:   5.7
  * Tested up to: 		6.0
  * Requires PHP:        7.2
@@ -18,7 +18,7 @@ defined('ABSPATH') or die('Jog on!');
  */
 
 define( 'WS_LS_ABSPATH', plugin_dir_path( __FILE__ ) );
-define( 'WE_LS_CURRENT_VERSION', '10.2' );
+define( 'WE_LS_CURRENT_VERSION', '10.2.1' );
 define( 'WE_LS_TITLE', 'Weight Tracker' );
 define( 'WE_LS_SLUG', 'weight-loss-tracker' );
 define( 'WE_LS_LICENSE_TYPES_URL', 'https://docs.yeken.uk/features.html' );


### PR DESCRIPTION
* Bug fix: [wt-kiosk] now passes the arguments correctly to the underlying [wt-beta] shortcode.
* Bug fix: When showing today's entries for the group, then show the correct label "Diff from start".
