### PR TITLE
10.3.1

### DIFF
--- a/includes/components.php
+++ b/includes/components.php
@@ -381,19 +381,24 @@ function ws_ls_component_target_weight( $args = [] ) {
 		$text_data  = $target_weight[ 'display' ];
 	}
 
+	if ( false === ws_ls_targets_enabled() ) {
+		$text_data = __( 'Targets not enabled in settings', WE_LS_SLUG );
+	}
+
 	return sprintf( '<div>
                         <div class="ykuk-card ykuk-card-small ykuk-card-body ykuk-box-shadow-small">
-                                <span class="ykuk-info-box-header">%3$s</span><br />
+                                <span class="ykuk-info-box-header %4$s">%3$s</span><br />
                                 <span class="ykuk-text-bold">
                                     %1$s
                                 </span>
                                 %2$s
-                                <br /><span class="ykuk-info-box-meta"><a href="#" class="ws-ls-tab-change" data-tab="settings">Adjust</a></span>
+                                <br /><span class="ykuk-info-box-meta %4$s"><a href="#" class="ws-ls-tab-change" data-tab="settings">Adjust</a></span>
                         </div>
                     </div>',
 		$text_data,
 		$text_date,
-		__( 'Target Weight', WE_LS_SLUG )
+		__( 'Target Weight', WE_LS_SLUG ),
+		! ws_ls_targets_enabled() ? 'ws-ls-hide' : ''
 	);
 }
 

--- a/includes/shortcode-wt.php
+++ b/includes/shortcode-wt.php
@@ -258,10 +258,13 @@ function ws_ls_wt_tab_menu( $arguments = [] ) {
 		$tabs[] = [ 'name' => 'gallery', 'icon' => 'image' ];
 	}
 
-	$tabs[] = [ 'name' => 'messages', 'icon' => 'mail' ];
+	if( true === ws_ls_note_is_enabled() ) {
+		$tabs[] = [ 'name' => 'messages', 'icon' => 'mail' ];
+	}
 
 	if( true === ws_ls_user_preferences_is_enabled() ||
-			true === $arguments[ 'kiosk-mode' ] ) {
+	        true === ws_ls_targets_enabled() ||
+				true === $arguments[ 'kiosk-mode' ] ) {
 		$tabs[] = [ 'name' => 'settings', 'icon' => 'settings' ];
 	}
 
@@ -324,7 +327,8 @@ function ws_ls_wt_tab_panes( $arguments = [] ) {
 	}
 
 	if( true === ws_ls_user_preferences_is_enabled() ||
-	        true === $arguments[ 'kiosk-mode' ] ) {
+	        true === ws_ls_targets_enabled() ||
+	            true === $arguments[ 'kiosk-mode' ] ) {
 		$html .= '<li>' . ws_ls_tab_settings( $arguments ) . '</li>';
 	}
 

--- a/includes/shortcode-wt.php
+++ b/includes/shortcode-wt.php
@@ -412,29 +412,32 @@ function ws_ls_tab_settings( $arguments = [] ) {
 		]);
 	}
 
-	$settings = ws_ls_user_preferences_form( [  'user-id'           => $arguments[ 'user-id' ],
-	                                            'uikit'             => true,
-												'show-delete-data'  => false,
-												'kiosk-mode'        => $arguments[ 'kiosk-mode' ],
-												'redirect-url'      => $redirect_url
-	]);
+	if( true === ws_ls_user_preferences_is_enabled() ) {
 
-	$html .= ws_ls_ui_kit_info_box_with_header_footer( [    'header'    => __( 'Settings', WE_LS_SLUG ),
-	                                                        'body'      => $settings
-	]);
-
-	if( true === $arguments[ 'show-delete-data' ] ) {
-		$settings = ws_ls_user_preferences_form( [  'user-id'               => $arguments[ 'user-id' ],
-		                                            'hide-titles'           => true,
-		                                            'uikit'                 => true,
-		                                            'show-user-preferences' => false,
-		                                            'kiosk-mode'            => $arguments[ 'kiosk-mode' ],
-													'redirect-url'          => $redirect_url
+		$settings = ws_ls_user_preferences_form( [  'user-id'           => $arguments[ 'user-id' ],
+		                                            'uikit'             => true,
+		                                            'show-delete-data'  => false,
+		                                            'kiosk-mode'        => $arguments[ 'kiosk-mode' ],
+		                                            'redirect-url'      => $redirect_url
 		]);
 
-		$html .= ws_ls_ui_kit_info_box_with_header_footer( [    'header'    => __( 'Delete your existing data', WE_LS_SLUG ),
+		$html .= ws_ls_ui_kit_info_box_with_header_footer( [    'header'    => __( 'Settings', WE_LS_SLUG ),
 		                                                        'body'      => $settings
 		]);
+
+		if( true === $arguments[ 'show-delete-data' ] ) {
+			$settings = ws_ls_user_preferences_form( [  'user-id'               => $arguments[ 'user-id' ],
+			                                            'hide-titles'           => true,
+			                                            'uikit'                 => true,
+			                                            'show-user-preferences' => false,
+			                                            'kiosk-mode'            => $arguments[ 'kiosk-mode' ],
+			                                            'redirect-url'          => $redirect_url
+			]);
+
+			$html .= ws_ls_ui_kit_info_box_with_header_footer( [    'header'    => __( 'Delete your existing data', WE_LS_SLUG ),
+			                                                        'body'      => $settings
+			]);
+		}
 	}
 
 	return $html;

--- a/pro-features/footable.php
+++ b/pro-features/footable.php
@@ -363,7 +363,9 @@ function ws_ls_datatable_columns( $arguments = [] ) {
 	if ( true === $arguments[ 'enable-weight' ] ) {
 		$columns[] = [ 'name' => 'kg', 'title' => __( 'Weight', WE_LS_SLUG ), 'visible'=> true, 'type' => 'text' ];
 
-		$columns[] = [ 'name' => 'gainloss', 'title' => ws_ls_tooltip('+/-', __( 'Difference', WE_LS_SLUG ) ), 'visible'=> true, 'breakpoints'=> 'xs', 'type' => 'text' ];
+		if ( false === $arguments[ 'front-end' ] || true === WS_LS_IS_PRO ) {
+			$columns[] = [ 'name' => 'gainloss', 'title' => ws_ls_tooltip('+/-', __( 'Difference', WE_LS_SLUG ) ), 'visible'=> true, 'breakpoints'=> 'xs', 'type' => 'text' ];
+		}
 	}
 
 	// Add BMI?

--- a/readme.txt
+++ b/readme.txt
@@ -156,6 +156,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 * Bug fix: Do not show gain/loss column within data tables (on main site) when not in Pro or Pro plus mode.
 * Bug fix: [wt] - enable the settings tab if Targets enabled when not in Pro or Pro plus mode.
 * Bug fix: [wt] - Don't display the messages tab if messages aren't enabled.
+* Bug fix: [wt] - Don't display target component if targets have been disabled in admin.
 
 = 10.3 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -155,6 +155,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 * Bug fix: Do not show gain/loss column within data tables (on main site) when not in Pro or Pro plus mode.
 * Bug fix: [wt] - enable the settings tab if Targets enabled when not in Pro or Pro plus mode.
+* Bug fix: [wt] - Don't display the messages tab if messages aren't enabled.
 
 = 10.3 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -151,6 +151,10 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 == Changelog ==
 
+= 10.3.1 =
+
+* Bug fix: Do not show gain/loss column within data tables (on main site) when not in Pro or Pro plus mode.
+
 = 10.3 =
 
 * New feature: Added the shortcode [wt-waist-to-hip-ratio-calculator] which renders a hip-to-waist ratio calculator. https://docs.yeken.uk/shortcodes/wt-waist-to-hip-ratio-calculator.html

--- a/readme.txt
+++ b/readme.txt
@@ -154,6 +154,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 = 10.3.1 =
 
 * Bug fix: Do not show gain/loss column within data tables (on main site) when not in Pro or Pro plus mode.
+* Bug fix: [wt] - enable the settings tab if Targets enabled when not in Pro or Pro plus mode.
 
 = 10.3 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aliakro
 Tags: weight,tracker,chart,bmi,bmr,macronutrient,measure,awards,custom fields,history,measurements,data
 Requires at least: 5.7
 Tested up to: 6.0.2
-Stable tag: 10.3
+Stable tag: 10.3.1
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die('Jog on!');
 /**
  * Plugin Name:         Weight Tracker
  * Description:         Allow your users to track their weight, body measurements, photos and other pieces of custom data. Display in charts, tables, shortcodes and widgets. Manage their data, issue awards, email notifications, etc! Provide advanced data on Body Mass Index (BMI), Basal Metabolic Rate (BMR), Calorie intake, Harris Benedict Formula, Macronutrients Calculator and more.
- * Version:             10.3
+ * Version:             10.3.1
  * Requires at least:   5.7
  * Tested up to: 		6.0.2
  * Requires PHP:        7.2
@@ -18,7 +18,7 @@ defined('ABSPATH') or die('Jog on!');
  */
 
 define( 'WS_LS_ABSPATH', plugin_dir_path( __FILE__ ) );
-define( 'WE_LS_CURRENT_VERSION', '10.3' );
+define( 'WE_LS_CURRENT_VERSION', '10.3.1' );
 define( 'WE_LS_TITLE', 'Weight Tracker' );
 define( 'WE_LS_SLUG', 'weight-loss-tracker' );
 define( 'WE_LS_LICENSE_TYPES_URL', 'https://docs.yeken.uk/features.html' );


### PR DESCRIPTION
* Bug fix: Do not show gain/loss column within data tables (on main site) when not in Pro or Pro plus mode.
* Bug fix: [wt] - enable the settings tab if Targets enabled when not in Pro or Pro plus mode.
* Bug fix: [wt] - Don't display the messages tab if messages aren't enabled.
* Bug fix: [wt] - Don't display target component if targets have been disabled in admin.