### PR TITLE
Sort meta fields by group_id first

### DIFF
--- a/pro-features/plus/meta-fields/db.php
+++ b/pro-features/plus/meta-fields/db.php
@@ -232,7 +232,7 @@ function ws_ls_meta_fields( $exclude_system = true, $ignore_cache = false ) {
         $sql .= ' Where `system` = 0';
     }
 
-    $sql .= ' order by sort, field_name asc';
+    $sql .= ' order by group_id, sort, field_name asc';
 
     $data = $wpdb->get_results( $sql , ARRAY_A );
 


### PR DESCRIPTION
If meta fields are grouped, then it would be useful to keep related fields together when displaying them