### PR TITLE
10.5

### DIFF
--- a/includes/admin-pages/settings/page-settings-generic.php
+++ b/includes/admin-pages/settings/page-settings-generic.php
@@ -281,7 +281,7 @@ function ws_ls_settings_page_generic() {
 													<th scope="row"><?php echo __( 'Enabled' , WE_LS_SLUG); ?></th>
 													<td>
 														<?php
-														$challenges_enabled = get_option( 'ws-ls-challenges-enabled', 'yes' );
+														    $challenges_enabled = get_option( 'ws-ls-challenges-enabled', 'yes' );
 														?>
 														<select id="ws-ls-challenges-enabled" name="ws-ls-challenges-enabled">
 															<option value="yes" <?php selected( $challenges_enabled, 'yes' ); ?>><?php echo __( 'Yes', WE_LS_SLUG ); ?></option>
@@ -291,6 +291,22 @@ function ws_ls_settings_page_generic() {
 													</td>
 												</tr>
 											</table>
+                                            <h3><?php echo __( 'Awards' , WE_LS_SLUG); ?></h3>
+                                            <table class="form-table">
+                                                <tr class="<?php echo $disable_if_not_pro_class; ?>">
+                                                    <th scope="row"><?php echo __( 'Delete awards when weight entry deleted?' , WE_LS_SLUG); ?></th>
+                                                    <td>
+														<?php
+														    $awards_enabled = get_option( 'ws-ls-awards-delete-when-entry-deleted-enabled', 'no' );
+														?>
+                                                        <select id="ws-ls-awards-delete-when-entry-deleted-enabled" name="ws-ls-awards-delete-when-entry-deleted-enabled">
+                                                            <option value="yes" <?php selected( $awards_enabled, 'yes' ); ?>><?php echo __( 'Yes', WE_LS_SLUG ); ?></option>
+                                                            <option value="no" <?php selected( $awards_enabled, 'no' ); ?>><?php echo __( 'No', WE_LS_SLUG ); ?></option>
+                                                        </select>
+                                                        <p> <?php echo __( 'If set to yes, when a weight entry is deleted (for awards given in versions 10.5 and above) any awards that were given at that time are also deleted. Please note, awards will automatically be re-added when a new entry is added if the entry meets the award criteria. ', WE_LS_SLUG ); ?> "></p>
+                                                    </td>
+                                                </tr>
+                                            </table>
                                             <h3><?php echo __( 'Photos' , WE_LS_SLUG); ?></h3>
                                             <table class="form-table">
                                                 <tr class="<?php echo $disable_if_not_pro_class; ?>">
@@ -1268,6 +1284,7 @@ function ws_ls_register_settings(){
 		register_setting( 'we-ls-options-group', 'ws-ls-cal-add-unit' );
 		register_setting( 'we-ls-options-group', 'ws-ls-cal-lose-unit' );
 		register_setting( 'we-ls-options-group', 'ws-ls-challenges-enabled' );
+	    register_setting( 'we-ls-options-group', 'ws-ls-awards-delete-when-entry-deleted-enabled' );
 
 		register_setting( 'we-ls-options-group', 'ws-ls-macro-proteins-maintain' );
 		register_setting( 'we-ls-options-group', 'ws-ls-macro-carbs-maintain' );

--- a/pro-features/plus/awards/activate.php
+++ b/pro-features/plus/awards/activate.php
@@ -45,6 +45,7 @@ function ws_ls_awards_create_mysql_tables() {
                 id mediumint(9) NOT NULL AUTO_INCREMENT,
                 user_id int NOT NULL,
                 award_id int NOT NULL,
+                added_by_entry_id int NULL,
                 timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 UNIQUE KEY id (id)
             ) $charset_collate;";

--- a/pro-features/plus/awards/db.php
+++ b/pro-features/plus/awards/db.php
@@ -46,11 +46,20 @@
      * @param $award_id
      * @return bool
      */
-    function ws_ls_awards_db_given_add( $user_id, $award_id ) {
+    function ws_ls_awards_db_given_add( $user_id, $award_id, $added_by_entry_id = NULL ) {
 
         global $wpdb;
 
-        $result = $wpdb->insert( $wpdb->prefix . WE_LS_MYSQL_AWARDS_GIVEN , [ 'user_id' => $user_id , 'award_id' => $award_id ], [ '%d', '%d' ] );
+		$data       = [ 'user_id' => $user_id , 'award_id' => $award_id ];
+		$formats    = [ '%d', '%d' ];
+
+		// added_by_entry_id, will allow us to track which weight entry the award was given for. Therefore, if the entry is deleted, we can delete the award(s) too.
+		if ( false === empty( $added_by_entry_id ) ) {
+			$data['added_by_entry_id'] = $added_by_entry_id;
+			$formats[]                 = '%d';
+		}
+
+        $result = $wpdb->insert( $wpdb->prefix . WE_LS_MYSQL_AWARDS_GIVEN , $data, $formats );
 
         ws_ls_cache_user_delete( $user_id );
 
@@ -260,30 +269,30 @@
     function ws_ls_awards_formats( $data ) {
 
         $formats = [
-            'id' => '%d',
-            'title' => '%s',
-            'category' => '%s',
-            'gain_loss' => '%s',
-            'badge' => '%d',
-	        'bmi_equals' => '%d',
-            'url' => '%s',
-            'compare' => '%s',
-            'custom_message' => '%s',
-            'max_awards' => '%d',
-            'enabled' => '%d',
-            'send_email' => '%d',
-            'apply_to_update' => '%d',
-            'apply_to_add' => '%d',
-            'value' => '%s'
+				        'id'              => '%d',
+				        'title'           => '%s',
+				        'category'        => '%s',
+				        'gain_loss'       => '%s',
+				        'badge'           => '%d',
+				        'bmi_equals'      => '%d',
+				        'url'             => '%s',
+				        'compare'         => '%s',
+				        'custom_message'  => '%s',
+				        'max_awards'      => '%d',
+				        'enabled'         => '%d',
+				        'send_email'      => '%d',
+				        'apply_to_update' => '%d',
+				        'apply_to_add'    => '%d',
+				        'value'           => '%s'
         ];
 
-        $return = [];
+	    $return = [];
 
-        foreach ( $data as $key => $value) {
-            if ( false === empty( $formats[ $key ] ) ) {
-                $return[] = $formats[ $key ];
-            }
-        }
+	    foreach ( $data as $key => $value ) {
+		    if ( false === empty( $formats[ $key ] ) ) {
+			    $return[] = $formats[ $key ];
+		    }
+	    }
 
         return $return;
     }

--- a/pro-features/plus/awards/hooks.php
+++ b/pro-features/plus/awards/hooks.php
@@ -218,7 +218,9 @@ add_action( 'wlt-hook-data-added-edited', 'ws_ls_awards_listen', 10, 2 );
  */
 function ws_ls_awards_listen_entry_deleted( $entry ) {
 
-	// TODO: Add new setting to enable / disable this!
+	if ( 'yes' !== get_option( 'ws-ls-awards-delete-when-entry-deleted-enabled', 'no' ) ) {
+		return;
+	}
 
 	if( false === empty( $entry[ 'id' ] ) ) {
 		ws_ls_awards_db_delete_awards_for_given_entry_id( $entry[ 'id' ], $entry[ 'user-id' ] );

--- a/pro-features/plus/awards/hooks.php
+++ b/pro-features/plus/awards/hooks.php
@@ -213,6 +213,22 @@ function ws_ls_awards_listen( $info, $weight_object ) {
 add_action( 'wlt-hook-data-added-edited', 'ws_ls_awards_listen', 10, 2 );
 
 /**
+ * If a user deletes an entry, then check whether there are any awards to delete.
+ * @param $entry
+ */
+function ws_ls_awards_listen_entry_deleted( $entry ) {
+
+	// TODO: Add new setting to enable / disable this!
+
+	if( false === empty( $entry[ 'id' ] ) ) {
+		ws_ls_awards_db_delete_awards_for_given_entry_id( $entry[ 'id' ], $entry[ 'user-id' ] );
+	}
+
+}
+add_action( 'wlt-hook-data-entry-deleted', 'ws_ls_awards_listen_entry_deleted' );
+
+
+/**
  * Log award
  *
  * @param $weight_object

--- a/pro-features/plus/awards/hooks.php
+++ b/pro-features/plus/awards/hooks.php
@@ -54,7 +54,7 @@ function ws_ls_awards_listen( $info, $weight_object ) {
 						if ( (( $user_aim === 2 ) && $weight_object['kg'] <= $target_kg ) ||
 						     ( 3 === $user_aim && $weight_object['kg'] >= $target_kg )  ) {
 
-							ws_ls_awards_db_given_add( $info['user-id'], $weight_award['id'] );
+							ws_ls_awards_db_given_add( $info['user-id'], $weight_award['id'], $weight_object[ 'id' ] );
 
 							// Throw hook out so other's can process award e.g. send emails. Log etc.
 							do_action( 'wlt-award-given', $weight_object, $weight_award, $info );
@@ -85,7 +85,7 @@ function ws_ls_awards_listen( $info, $weight_object ) {
                     if ( ( true === $losing_weight && 'loss' === $weight_award['gain_loss'] ) ||
                             ( false === $losing_weight && 'gain' === $weight_award['gain_loss'] )  ) {
 
-                        ws_ls_awards_db_given_add( $info['user-id'], $weight_award['id'] );
+                        ws_ls_awards_db_given_add( $info['user-id'], $weight_award['id'], $weight_object[ 'id' ] );
 
                         // Throw hook out so other's can process award e.g. send emails. Log etc.
                         do_action( 'wlt-award-given', $weight_object, $weight_award, $info );
@@ -124,7 +124,7 @@ function ws_ls_awards_listen( $info, $weight_object ) {
 
 								if ( $current_label === $award_label ) {
 
-									ws_ls_awards_db_given_add( $info['user-id'], $bmi_award['id'] );
+									ws_ls_awards_db_given_add( $info['user-id'], $bmi_award['id'], $weight_object[ 'id' ]  );
 
 									// Throw hook out so other's can process award e.g. send emails. Log etc.
 									do_action( 'wlt-award-given', $weight_object, $bmi_award, $info );
@@ -163,7 +163,7 @@ function ws_ls_awards_listen( $info, $weight_object ) {
 
                                 if ( ( false === $increase_in_bmi && 'loss' === $bmi_award['gain_loss'] ) || ( true === $increase_in_bmi && 'gain' === $bmi_award['gain_loss'] ) ) {
 
-                                    ws_ls_awards_db_given_add( $info['user-id'], $bmi_award['id'] );
+                                    ws_ls_awards_db_given_add( $info['user-id'], $bmi_award['id'], $weight_object[ 'id' ] );
 
                                     // Throw hook out so other's can process award e.g. send emails. Log etc.
                                     do_action( 'wlt-award-given', $weight_object, $bmi_award, $info );
@@ -199,7 +199,7 @@ function ws_ls_awards_listen( $info, $weight_object ) {
                             continue;
                         }
 
-                        ws_ls_awards_db_given_add( $info['user-id'], $percentage_award['id'] );
+                        ws_ls_awards_db_given_add( $info['user-id'], $percentage_award['id'], $weight_object[ 'id' ] );
 
                         do_action( 'wlt-award-given', $weight_object, $percentage_award, $info );
 

--- a/pro-features/plus/meta-fields/activate.php
+++ b/pro-features/plus/meta-fields/activate.php
@@ -94,10 +94,7 @@
 	        }
 
 	        ws_ls_meta_fields_photos_create_example_field();
-
-	        // Do we need to migrate measurements?
-			ws_ls_migrate_measurements_into_meta_fields();
-
+			
         }
     }
     add_action( 'admin_init', 'ws_ls_activate_meta_fields_activate' );

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,10 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 == Changelog ==
 
+= 10.5 =
+
+* Bug fix: Removed reference to ws_ls_migrate_measurements_into_meta_fields() which was causing a fatal error for some users.
+
 = 10.4 =
 
 * New feature: New Setting "Who can export and delete user data?" to allow you to specify which roles can export and delete user data.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aliakro
 Tags: weight,tracker,chart,bmi,bmr,macronutrient,measure,awards,custom fields,history,measurements,data
 Requires at least: 5.7
 Tested up to: 6.3
-Stable tag: 10.4
+Stable tag: 10.5
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -154,6 +154,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 = 10.5 =
 
+* Improvement: Added a new setting "Delete awards when weight entry deleted?". If enabled, any awards that were awarded to a user will be deleted when the weight entry is deleted (only works with awards added in version 10.5 onwards). Read more: https://github.com/alicolville/Weight-Tracker/issues/549
 * Bug fix: Removed reference to ws_ls_migrate_measurements_into_meta_fields() which was causing a fatal error for some users.
 
 = 10.4 =

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -18,7 +18,7 @@ defined('ABSPATH') or die('Jog on!');
  */
 
 define( 'WS_LS_ABSPATH', plugin_dir_path( __FILE__ ) );
-define( 'WE_LS_CURRENT_VERSION', '10.4' );
+define( 'WE_LS_CURRENT_VERSION', '10.4b' );
 define( 'WE_LS_TITLE', 'Weight Tracker' );
 define( 'WE_LS_SLUG', 'weight-loss-tracker' );
 define( 'WE_LS_LICENSE_TYPES_URL', 'https://docs.yeken.uk/features.html' );

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die('Jog on!');
 /**
  * Plugin Name:         Weight Tracker
  * Description:         Allow your users to track their weight, body measurements, photos and other pieces of custom data. Display in charts, tables, shortcodes and widgets. Manage their data, issue awards, email notifications, etc! Provide advanced data on Body Mass Index (BMI), Basal Metabolic Rate (BMR), Calorie intake, Harris Benedict Formula, Macronutrients Calculator and more.
- * Version:             10.4
+ * Version:             10.5
  * Requires at least:   5.7
  * Tested up to: 		6.3
  * Requires PHP:        7.2
@@ -18,7 +18,7 @@ defined('ABSPATH') or die('Jog on!');
  */
 
 define( 'WS_LS_ABSPATH', plugin_dir_path( __FILE__ ) );
-define( 'WE_LS_CURRENT_VERSION', '10.4b' );
+define( 'WE_LS_CURRENT_VERSION', '10.5' );
 define( 'WE_LS_TITLE', 'Weight Tracker' );
 define( 'WE_LS_SLUG', 'weight-loss-tracker' );
 define( 'WE_LS_LICENSE_TYPES_URL', 'https://docs.yeken.uk/features.html' );


### PR DESCRIPTION
* Improvement: Added a new setting "Delete awards when weight entry deleted?". If enabled, any awards that were awarded to a user will be deleted when the weight entry is deleted (only works with awards added in version 10.5 onwards). Read more: https://github.com/alicolville/Weight-Tracker/issues/549
* Bug fix: Removed reference to ws_ls_migrate_measurements_into_meta_fields() which was causing a fatal error for some users.
