### PR TITLE
Maintenance

### DIFF
--- a/includes/core-forms.php
+++ b/includes/core-forms.php
@@ -82,7 +82,7 @@ function ws_ls_form_weight( $arguments = [] ) {
 									esc_attr( wp_hash( $arguments[ 'user-id' ] ) ),
 									( NULL === ws_ls_querystring_value( 'load-entry', NULL ) ) ? $arguments[ 'entry-id' ] : '',
 									( true === $arguments[ 'photos-enabled' ]  ) ? 'enctype="multipart/form-data"' : '',
-									esc_url_raw( $arguments[ 'redirect-url' ] ),
+                                    ( false === empty( $arguments[ 'redirect-url' ] ) ? esc_url_raw( $arguments[ 'redirect-url' ] ) : '' ),
 									$arguments[ 'form-number' ],
 									( 'weight' === $arguments[ 'type' ] && true === ws_ls_to_bool( $arguments[ 'weight-mandatory' ] ) ) ? 'weight-required ' : '',
 									$arguments[ 'form-key' ],
@@ -274,7 +274,7 @@ function ws_ls_form_weight( $arguments = [] ) {
  *
  * @return array
  */
-function  ws_ls_form_init( $arguments = [] ) {
+function ws_ls_form_init( $arguments = [] ) {
 
 	$user_id                    = ( false === $arguments[ 'kiosk-mode' ] ) ? $arguments[ 'user-id' ] : get_current_user_id();
 	$arguments[ 'form-id' ]     = ws_ls_component_id();

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,10 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 == Changelog ==
 
+= 10.*.* =
+
+* Maintenance: Updated Chart.js library to 4.4.1.
+
 = 10.8 =
 
 * New feature: Added new components to display custom fields (latest, previous and oldest) within summary boxes on [wt] shortcode. Read more: https://docs.yeken.uk/components.html

--- a/readme.txt
+++ b/readme.txt
@@ -155,6 +155,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 = 10.*.* =
 
 * Maintenance: Updated Chart.js library to 4.4.1.
+* Maintenance: Removed deprecated "ltrim()" warning when no redirect-url specified on [wt] and [wt-form]
 
 = 10.8 =
 

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -26,7 +26,7 @@ define( 'WE_LS_CALCULATIONS_URL', '	https://docs.yeken.uk/calculations.html' );
 define( 'WE_LS_UPGRADE_TO_PRO_URL', 'https://shop.yeken.uk/product/weight-tracker-pro/' );
 define( 'WE_LS_UPGRADE_TO_PRO_PLUS_URL', 'https://shop.yeken.uk/product/weight-tracker-pro-plus/' );
 define( 'WE_LS_FREE_TRIAL_URL', 'https://shop.yeken.uk/get-a-trial-license/' );
-define( 'WE_LS_CDN_CHART_JS', 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.2.0/chart.min.js' );
+define( 'WE_LS_CDN_CHART_JS', 'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js' );
 define( 'WE_LS_CDN_FONT_AWESOME_CSS', 'https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' );
 define( 'WE_LS_PRO_PRICE', 60.00 );
 define( 'WE_LS_PRO_PLUS_PRICE', 120.00 );


### PR DESCRIPTION
* Maintenance: Updated Chart.js library to 4.4.1.
* Maintenance: Removed deprecated "ltrim()" warning when no redirect-url specified on [wt] and [wt-form]