### PR TITLE
10.8.1

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -91,6 +91,14 @@ Display the oldest value for the given custom field. Replace [slug] with the des
 
 [![](/assets/images/component-latest-weight.png)](/assets/images/component-latest-weight.png)
 
+#### latest-weight-difference-as-percentage
+
+Same box as "latest-weight" but forces the difference to be displayed as a percentage.
+
+#### latest-weight-difference-as-weight
+
+Same box as "latest-weight" but forces the difference to be displayed in weight. 
+
 #### latest-versus-target
 
 [![](/assets/images/component-latest-versus-target.png)](/assets/images/component-latest-versus-target.png)

--- a/docs/shortcodes-text.md
+++ b/docs/shortcodes-text.md
@@ -63,7 +63,7 @@ Display the difference between the current user's most recent weight entry and t
     [wt-difference-between-latest-previous invert="true" display="percentage”] 
       
 Also supports the following arguments:
-* "display" - Specifies whether to display a "weight" (default) or "percentage"
+* "display" - Specifies whether to display a "weight" (default), "percentage" or "both".
 * "invert" to invert negative numbers into positive and vice versa e.g.
 * "include-percentage-sign" - if displaying a percentage, specifies whether or not to include the percentage sign. Accepts "true" (default) or "false".
 

--- a/docs/shortcodes-text.md
+++ b/docs/shortcodes-text.md
@@ -51,7 +51,7 @@ Display the difference between the current user's most recent weight entry and t
     [wt-difference-from-target invert="true" display="percentage"]
 
 Also supports the following arguments:
-* "display" - Specifies whether to display a "weight" (default) or "percentage"
+* "display" - Specifies whether to display a "weight" (default), "percentage" or "both".
 * "invert" to invert negative numbers into positive and vice versa e.g.
 * "include-percentage-sign" - if displaying a percentage, specifies whether or not to include the percentage sign. Accepts "true" (default) or "false".
 

--- a/includes/components.php
+++ b/includes/components.php
@@ -102,8 +102,12 @@ function ws_ls_uikit_summary_boxes( $arguments, $boxes = [] ) {
 				$html .= ws_ls_component_number_of_days_tracking( [ 'user-id' => $arguments[ 'user-id' ] ] );
 				break;
 			case 'latest-weight':
+			case 'latest-weight-difference-as-percentage':
 				$html .= ws_ls_component_latest_weight( [ 'user-id' => $arguments[ 'user-id' ] ] );
 				break;
+			case 'latest-weight-difference-as-weight':
+				$html .= ws_ls_component_latest_weight( [ 'user-id' => $arguments[ 'user-id' ], 'difference-display' => 'weight' ] );
+				break;	
 			case 'latest-award':
 				$html .= ws_ls_component_latest_award( [ 'user-id' => $arguments[ 'user-id' ] ] );
 				break;
@@ -226,7 +230,7 @@ function ws_ls_component_custom_field_render( $args) {
  */
 function ws_ls_component_latest_weight( $args = [] ) {
 
-    $args           = wp_parse_args( $args, [ 'user-id' => get_current_user_id() ] );
+    $args           = wp_parse_args( $args, [ 'difference-display' => 'percentage', 'user-id' => get_current_user_id() ] );
     $latest_entry   = ws_ls_entry_get_latest( $args );
 
     $text_date      = '';
@@ -240,9 +244,9 @@ function ws_ls_component_latest_weight( $args = [] ) {
 										<a href="%s">%s</a>
 									</span>', ws_ls_wt_link_edit_entry( $latest_entry[ 'id' ] ), $latest_entry[ 'display-date' ] );
 
-        $difference = ws_ls_shortcode_difference_in_weight_previous_latest( [   'display'                   => 'both',
+        $difference = ws_ls_shortcode_difference_in_weight_previous_latest( [   'display'                   => $args[ 'difference-display' ],
                                                                                 'include-percentage-sign'   => true,
-	                                                                            'invert'                    => true,
+	                                                                            'invert'                    => ( 'percentage' === $args[ 'difference-display' ] ),
                                                                                 'user-id'                   => $args[ 'user-id']
         ] );
 
@@ -257,7 +261,7 @@ function ws_ls_component_latest_weight( $args = [] ) {
 		        $class = 'ykuk-label-warning';
 	        }
 
-            $text_data .= sprintf( ' <span class="ykuk-label %s" ykuk-tooltip="%s">%s</span>',
+            $text_data .= sprintf( ' <span class="ykuk-label %s ykuk-width-1-1" ykuk-tooltip="%s">%s</span>',
                                     $class,
                                     __( 'The difference between your latest weight and previous.', WE_LS_SLUG ),
                                     $difference
@@ -290,7 +294,7 @@ function ws_ls_component_weight_difference_since_previous( $args = [] ) {
 
 	$args = wp_parse_args( $args, [ 'user-id' => get_current_user_id() ] );
 
-	$text_data = ws_ls_shortcode_difference_in_weight_previous_latest( [    'display'                   => 'weight',
+	$text_data = ws_ls_shortcode_difference_in_weight_previous_latest( [    'display'                   => 'percentage',
 	                                                                        'include-percentage-sign'   => false,
 	                                                                        'invert'                    => false,
 	                                                                        'user-id'                   => $args[ 'user-id'],

--- a/includes/components.php
+++ b/includes/components.php
@@ -240,8 +240,8 @@ function ws_ls_component_latest_weight( $args = [] ) {
 										<a href="%s">%s</a>
 									</span>', ws_ls_wt_link_edit_entry( $latest_entry[ 'id' ] ), $latest_entry[ 'display-date' ] );
 
-        $difference = ws_ls_shortcode_difference_in_weight_previous_latest( [   'display'                   => 'percentage',
-                                                                                'include-percentage-sign'   => false,
+        $difference = ws_ls_shortcode_difference_in_weight_previous_latest( [   'display'                   => 'both',
+                                                                                'include-percentage-sign'   => true,
 	                                                                            'invert'                    => true,
                                                                                 'user-id'                   => $args[ 'user-id']
         ] );
@@ -257,7 +257,7 @@ function ws_ls_component_latest_weight( $args = [] ) {
 		        $class = 'ykuk-label-warning';
 	        }
 
-            $text_data .= sprintf( ' <span class="ykuk-label %s" ykuk-tooltip="%s">%s%%</span>',
+            $text_data .= sprintf( ' <span class="ykuk-label %s" ykuk-tooltip="%s">%s</span>',
                                     $class,
                                     __( 'The difference between your latest weight and previous.', WE_LS_SLUG ),
                                     $difference

--- a/includes/shortcode-various.php
+++ b/includes/shortcode-various.php
@@ -258,6 +258,7 @@ function ws_ls_shortcode_difference_in_weight_previous_latest( $user_defined_arg
     if ( true === in_array(  $arguments[ 'display' ], [ 'both', 'weight' ] ) ) {
 
         $difference             = $latest_entry[ 'kg' ] - $previous_entry[ 'kg' ];
+		echo $difference;
         $difference             = ( false === ws_ls_to_bool( $arguments[ 'invert' ] ) ) ? $difference : -$difference ;
         $sign                   = ( $difference > 0 ) ? '+' : '';
         $weight_to_display      = ws_ls_weight_display( $difference, $arguments[ 'user-id' ], false, false, true );

--- a/includes/shortcode-various.php
+++ b/includes/shortcode-various.php
@@ -258,7 +258,6 @@ function ws_ls_shortcode_difference_in_weight_previous_latest( $user_defined_arg
     if ( true === in_array(  $arguments[ 'display' ], [ 'both', 'weight' ] ) ) {
 
         $difference             = $latest_entry[ 'kg' ] - $previous_entry[ 'kg' ];
-		echo $difference;
         $difference             = ( false === ws_ls_to_bool( $arguments[ 'invert' ] ) ) ? $difference : -$difference ;
         $sign                   = ( $difference > 0 ) ? '+' : '';
         $weight_to_display      = ws_ls_weight_display( $difference, $arguments[ 'user-id' ], false, false, true );

--- a/includes/shortcode-various.php
+++ b/includes/shortcode-various.php
@@ -90,7 +90,7 @@ function ws_ls_shortcode_difference_in_weight_previous_latest( $user_defined_arg
 
 	$arguments = shortcode_atts( [	'user-id' 					=> get_current_user_id(),
 									'invert' 					=> false,
-									'display' 					=> 'weight', // weight or percentage
+									'display' 					=> 'weight', // both, weight or percentage
 									'include-percentage-sign' 	=> true,
 									'kiosk-mode'                => false
 								]
@@ -118,7 +118,9 @@ function ws_ls_shortcode_difference_in_weight_previous_latest( $user_defined_arg
 		return '';
 	}
 
-	if ( 'percentage' == $arguments[ 'display' ] ) {
+    $html = '';
+
+	if ( true === in_array(  $arguments[ 'display' ], [ 'both', 'percentage' ] ) ) {
 
 		$output = ws_ls_calculate_percentage_difference( $previous_entry[ 'kg' ], $latest_entry[ 'kg' ] );
 
@@ -126,34 +128,40 @@ function ws_ls_shortcode_difference_in_weight_previous_latest( $user_defined_arg
 			return '';
 		}
 
-		$output = ( true === $output[ 'increase' ] ) ?  $output[ 'percentage' ] : -$output[ 'percentage' ];
+		$difference = ( true === $output[ 'increase' ] ) ?  $output[ 'percentage' ] : -$output[ 'percentage' ];
 
-		$output = ws_ls_round_number( $output, 1 );
+        $html .= ws_ls_round_number( $difference, 1 );
 
 		if ( true === $arguments[ 'include-percentage-sign' ] ) {
-			$output .= '%';
+            $html .= '%';
 		}
 
-	} else {
+	}
+
+    if ( 'both' == $arguments[ 'display' ] ) {
+        $html .= ' / ';
+    }
+
+    if ( true === in_array(  $arguments[ 'display' ], [ 'both', 'weight' ] ) ) {
 
 		$difference             = $latest_entry[ 'kg' ] - $previous_entry[ 'kg' ];
 		$difference             = ( false === ws_ls_to_bool( $arguments[ 'invert' ] ) ) ? $difference : -$difference ;
 		$sign                   = ( $difference > 0 ) ? '+' : '';
 		$weight_to_display      = ws_ls_weight_display( $difference, $arguments[ 'user-id' ], false, false, true );
-		$output                 = sprintf ('%s%s', $sign, $weight_to_display[ 'display' ] );
+        $html                   .= sprintf ('%s%s', $sign, $weight_to_display[ 'display' ] );
 
 		if ( true === $arguments[ 'kiosk-mode' ] ) {
 
 			// Note, this currently only supports lose weight!
 			$label = ( $difference <= 0 ) ? 'ykuk-label ykuk-label-success' : 'ykuk-label ykuk-label-warning';
 
-			$output = sprintf( '<span class="%s">%s</span>', $label, $output );
+            $html .= sprintf( '<span class="%s">%s</span>', $label, $html );
 		}
 	}
 
-	ws_ls_cache_user_set( $arguments[ 'user-id' ], $cache_key, $output );
+	ws_ls_cache_user_set( $arguments[ 'user-id' ], $cache_key, $html );
 
-	return $output;
+	return $html;
 }
 add_shortcode( 'wt-difference-between-latest-previous', 'ws_ls_shortcode_difference_in_weight_previous_latest' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -154,6 +154,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 = 10.*.* =
 
+* New feature: Added the option "both" to the "display" argument of [wt-difference-between-latest-previous]. This option will display both weight and percentage.
 * Maintenance: Updated Chart.js library to 4.4.1.
 * Maintenance: Removed deprecated "ltrim()" warning when no redirect-url specified on [wt] and [wt-form]
 

--- a/readme.txt
+++ b/readme.txt
@@ -154,6 +154,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 = 10.*.* =
 
+* New feature: Added the option "both" to the "display" argument of [wt-difference-from-target]. This option will display both weight and percentage.
 * New feature: Added the option "both" to the "display" argument of [wt-difference-between-latest-previous]. This option will display both weight and percentage.
 * Maintenance: Updated Chart.js library to 4.4.1.
 * Maintenance: Removed deprecated "ltrim()" warning when no redirect-url specified on [wt] and [wt-form]

--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 = 10.8 =
 
 * New feature: Added new components to display custom fields (latest, previous and oldest) within summary boxes on [wt] shortcode. Read more: https://docs.yeken.uk/components.html
+* New feature: Added the slightly new components "latest-weight-difference-as-percentage" and "latest-weight-difference-as-weight" to change how the difference figure of "latest-weight" is rendered". Read more: https://docs.yeken.uk/components.html
 
 = 10.7.3 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aliakro
 Tags: weight,tracker,chart,bmi,bmr,macronutrient,measure,awards,custom fields,history,measurements,data
 Requires at least: 6.0
 Tested up to: 6.4.3
-Stable tag: 10.8
+Stable tag: 10.8.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -152,17 +152,17 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 == Changelog ==
 
-= 10.*.* =
+= 10.8.1 =
 
 * New feature: Added the option "both" to the "display" argument of [wt-difference-from-target]. This option will display both weight and percentage.
 * New feature: Added the option "both" to the "display" argument of [wt-difference-between-latest-previous]. This option will display both weight and percentage.
+* New feature: Added the slightly new components "latest-weight-difference-as-percentage" and "latest-weight-difference-as-weight" to change how the difference figure of "latest-weight" is rendered". Read more: https://docs.yeken.uk/components.html
 * Maintenance: Updated Chart.js library to 4.4.1.
 * Maintenance: Removed deprecated "ltrim()" warning when no redirect-url specified on [wt] and [wt-form]
 
 = 10.8 =
 
 * New feature: Added new components to display custom fields (latest, previous and oldest) within summary boxes on [wt] shortcode. Read more: https://docs.yeken.uk/components.html
-* New feature: Added the slightly new components "latest-weight-difference-as-percentage" and "latest-weight-difference-as-weight" to change how the difference figure of "latest-weight" is rendered". Read more: https://docs.yeken.uk/components.html
 
 = 10.7.3 =
 

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die('Jog on!');
 /**
  * Plugin Name:         Weight Tracker
  * Description:         Allow your users to track their weight, body measurements, photos and other pieces of custom data. Display in charts, tables, shortcodes and widgets. Manage their data, issue awards, email notifications, etc! Provide advanced data on Body Mass Index (BMI), Basal Metabolic Rate (BMR), Calorie intake, Harris Benedict Formula, Macronutrients Calculator and more.
- * Version:             10.8
+ * Version:             10.8.1
  * Requires at least:   6.0
  * Tested up to: 		6.4.3
  * Requires PHP:        7.4
@@ -18,7 +18,7 @@ defined('ABSPATH') or die('Jog on!');
  */
 
 define( 'WS_LS_ABSPATH', plugin_dir_path( __FILE__ ) );
-define( 'WE_LS_CURRENT_VERSION', '10.8' );
+define( 'WE_LS_CURRENT_VERSION', '10.8.1' );
 define( 'WE_LS_TITLE', 'Weight Tracker' );
 define( 'WE_LS_SLUG', 'weight-loss-tracker' );
 define( 'WE_LS_LICENSE_TYPES_URL', 'https://docs.yeken.uk/features.html' );


### PR DESCRIPTION
* New feature: Added the option "both" to the "display" argument of [wt-difference-from-target]. This option will display both weight and percentage.
* New feature: Added the option "both" to the "display" argument of [wt-difference-between-latest-previous]. This option will display both weight and percentage.
* New feature: Added the slightly new components "latest-weight-difference-as-percentage" and "latest-weight-difference-as-weight" to change how the difference figure of "latest-weight" is rendered". Read more: https://docs.yeken.uk/components.html
* Maintenance: Updated Chart.js library to 4.4.1.
* Maintenance: Removed deprecated "ltrim()" warning when no redirect-url specified on [wt] and [wt-form]
