### PR TITLE
10.9

### DIFF
--- a/docs/shortcodes/wt-user-settings.md
+++ b/docs/shortcodes/wt-user-settings.md
@@ -21,6 +21,7 @@ The shortcode supports the following arguments:
 |hide-dob|Hide Date of Birth field|true or false (default)|[wt-user-settings hide-dob=true]
 |hide-extras|Hide additional fields|true or false (default)|[wt-user-settings hide-extras=true]
 |hide-height|Hide height field|true or false (default)|[wt-user-settings hide-height=true]
+| hide-email-optout | Hide the email opt out form. | True or false (default).  | [wt-user-settings hide-email-optout=true] | 
 |hide-gender|Hide gender field|true or false (default)|[wt-user-settings hide-gender=true]
 |hide-preferences|Hide preference fields|true or false (default)|[wt-user-settings hide-preferences=true]
 |hide-titles|Hide the section titles|True or false (default)|[wt-user-settings hide-titles=true]

--- a/docs/shortcodes/wt.md
+++ b/docs/shortcodes/wt.md
@@ -100,7 +100,8 @@ The shortcode supports the following arguments:
 | hide-chart-overview   |  Hide the chart from the "Overview" tab.   | True or false (default).  | [wt hide-chart-overview=true] |     
 | hide-custom-fields-chart   |  Hide custom fields from the chart.   | True or false (default).  | [wt hide-custom-fields-chart=true] |     
 | hide-custom-fields-form   |  Hide custom fields from the form.   | True or false (default).  | [wt hide-custom-fields-form=true] |     
-| hide-custom-fields-table   |  Hide custom fields from the table.   | True or false (default).  | [wt hide-custom-fields-table=true] |     					
+| hide-custom-fields-table   |  Hide custom fields from the table.   | True or false (default).  | [wt hide-custom-fields-table=true] |     	
+| hide-email-optout | Hide the email opt out form on settings tab. | True or false (default).  | [wt hide-email-optout=true] |  				
 | hide-first-target-form | Hide the target form from the Overview tab. | True or false (default).  | [wt hide-first-target-form=true] |  
 | hide-notes | If set to true (default is false) hide the "notes" section of the form.   | True or false (default).   | [wt hide-notes=true] |   
 | hide-notifications | If set to true (default is false) hide the "notifications" at the top of the shortcode.   | True or false (default).   | [wt hide-notifications=true] |   

--- a/includes/admin-pages/settings/page-settings-generic.php
+++ b/includes/admin-pages/settings/page-settings-generic.php
@@ -321,21 +321,7 @@ function ws_ls_settings_page_generic() {
                                                     </td>
                                                 </tr>
                                             </table>
-                                            <h3><?php echo __( 'Birthday Emails' , WE_LS_SLUG); ?></h3>
-                                            <table class="form-table">
-                                                <tr class="<?php echo $disable_if_not_pro_class; ?>">
-                                                    <th scope="row"><?php echo __( 'Enable?' , WE_LS_SLUG); ?></th>
-                                                    <td>
-                                                        <select id="ws-ls-enable-birthdays" name="ws-ls-enable-birthdays">
-                                                            <option value="no" <?php selected( get_option('ws-ls-enable-birthdays'), 'no' ); ?>><?php echo __('No', WE_LS_SLUG)?></option>
-                                                            <option value="yes" <?php selected( get_option('ws-ls-enable-birthdays'), 'yes' ); ?>><?php echo __('Yes', WE_LS_SLUG)?></option>
-                                                        </select>
-                                                        <p><?php echo __('If enabled, a Happy Birthday email shall be sent to users on their birthday.', WE_LS_SLUG)?></p>
-
-                                                    </td>
-                                                </tr>
-                                            </table>
-                                            <h3><?php echo __( 'Advanced' , WE_LS_SLUG); ?></h3>
+                                           <?php echo __( 'Advanced' , WE_LS_SLUG); ?></h3>
                                             <table class="form-table">
                                                 <tr>
                                                     <th scope="row"><?php echo __( 'Disable plugin CSS?' , WE_LS_SLUG); ?></th>
@@ -881,7 +867,21 @@ function ws_ls_settings_page_generic() {
                                                     ws_ls_display_pro_upgrade_notice();
                                                 }
                                                 ?>
-												<h3><?php echo __( 'Settings' , WE_LS_SLUG); ?></h3>
+												<h3><?php echo __( 'User notifications' , WE_LS_SLUG); ?></h3>
+												<table class="form-table">
+													<tr class="<?php echo $disable_if_not_pro_class; ?>">
+														<th scope="row"><?php echo __( 'Birthday Emails' , WE_LS_SLUG); ?></th>
+														<td>
+															<select id="ws-ls-enable-birthdays" name="ws-ls-enable-birthdays">
+																<option value="no" <?php selected( get_option('ws-ls-enable-birthdays'), 'no' ); ?>><?php echo __('No', WE_LS_SLUG)?></option>
+																<option value="yes" <?php selected( get_option('ws-ls-enable-birthdays'), 'yes' ); ?>><?php echo __('Yes', WE_LS_SLUG)?></option>
+															</select>
+															<p><?php echo __('If enabled, a Happy Birthday email shall be sent to users on their birthday. Note: This can be disabled by the user.', WE_LS_SLUG)?></p>
+
+														</td>
+													</tr>
+												</table>
+												<h3><?php echo __( 'Admin notifications' , WE_LS_SLUG); ?></h3>
 												<table class="form-table">
 													<tr class="<?php echo $disable_if_not_pro_class; ?>">
 														<th scope="row"><?php echo __( 'Enable email notifications', WE_LS_SLUG ); ?></th>

--- a/includes/admin-pages/settings/page-settings-generic.php
+++ b/includes/admin-pages/settings/page-settings-generic.php
@@ -1048,6 +1048,19 @@ function ws_ls_settings_page_generic() {
 													</td>
 												</tr>
 												<tr class="<?php echo $disable_if_not_pro_class; ?>">
+													<th scope="row"><?php echo __( 'Send data for new notes?', WE_LS_SLUG ); ?></th>
+													<td>
+														<?php
+														$is_enabled = get_option( 'ws-ls-webhooks-new-note-enabled', 'no' );
+														?>
+														<select id="ws-ls-webhooks-new-note-enabled" name="ws-ls-webhooks-new-note-enabled">
+															<option value="yes" <?php selected( $is_enabled, 'yes' ); ?>><?php echo __('Yes', WE_LS_SLUG)?></option>
+															<option value="no" <?php selected( $is_enabled, 'no' ); ?>><?php echo __('No', WE_LS_SLUG)?></option>
+														</select>
+														<p><?php echo __( 'When a user receives a new note, should data be fired to the endpoint(s)?', WE_LS_SLUG); ?></p>
+													</td>
+												</tr>
+												<tr class="<?php echo $disable_if_not_pro_class; ?>">
 													<th scope="row"><?php echo __( 'Include admin updates?', WE_LS_SLUG ); ?></th>
 													<td>
 														<?php
@@ -1182,6 +1195,7 @@ function ws_ls_register_settings(){
 		register_setting( 'we-ls-options-group', 'ws-ls-webhooks-admin-changes-enabled' );
 		register_setting( 'we-ls-options-group', 'ws-ls-webhooks-weight-entries-enabled' );
 		register_setting( 'we-ls-options-group', 'ws-ls-webhooks-targets-enabled' );
+		register_setting( 'we-ls-options-group', 'ws-ls-webhooks-new-note-enabled' );
 
         // Photos
 	    register_setting( 'we-ls-options-group', 'ws-ls-photos-max-size' );

--- a/includes/db.php
+++ b/includes/db.php
@@ -576,6 +576,11 @@ function  ws_ls_set_user_preferences( $in_admin_area, $fields = [] ) {
 	    $db_fields[ 'settings' ] = json_encode( $db_fields['settings'] );
     }
 
+	if ( true === isset( $db_fields[ 'email_lists' ] ) &&
+            true === is_array( $db_fields['email_lists'] ) ) {
+	    $db_fields[ 'email_lists' ] = json_encode( $db_fields['email_lists'] );
+    }
+	
 	if ( false === empty( $db_fields['dob'] ) ) {
 		$db_fields['dob'] = ws_ls_convert_date_to_iso( $db_fields[ 'dob' ], ( $in_admin_area ) ? false : $db_fields[ 'user_id' ] );
 	}

--- a/includes/db.php
+++ b/includes/db.php
@@ -707,6 +707,7 @@ function ws_ls_user_preferences_get_formats( $db_fields ) {
 			    'activity_level'    => '%f',
 			    'aim'               => '%d',
 			    'dob'               => '%s',
+				'email_lists'       => '%s',
 			    'gender'            => '%d',
 			    'height'            => '%d',
 		        'settings'          => '%s',

--- a/includes/db.php
+++ b/includes/db.php
@@ -907,6 +907,7 @@ function ws_ls_db_create_core_tables() {
              dob datetime NULL,
              body_type float DEFAULT 0 NULL,
              challenge_opt_in float DEFAULT -1 NULL,
+			 email_lists text null,
 			 UNIQUE KEY user_id (user_id)
 	 ) $charset_collate;";
 

--- a/includes/db.php
+++ b/includes/db.php
@@ -564,7 +564,7 @@ function ws_ls_db_dates_min_max_get( $user_id ) {
  *
  * @return bool|false|int
  */
-function ws_ls_set_user_preferences( $in_admin_area, $fields = [] ) {
+function  ws_ls_set_user_preferences( $in_admin_area, $fields = [] ) {
 
 	$user_id = ( false === empty( $fields[ 'user_id' ] ) ) ? (int) $fields[ 'user_id' ] : get_current_user_id();
 
@@ -706,6 +706,7 @@ function ws_ls_user_preferences_get_formats( $db_fields ) {
     $lookup = [
 			    'activity_level'    => '%f',
 			    'aim'               => '%d',
+				'body_type'         => '%d',
 			    'dob'               => '%s',
 				'email_lists'       => '%s',
 			    'gender'            => '%d',

--- a/includes/email-manager.php
+++ b/includes/email-manager.php
@@ -655,6 +655,7 @@ function ws_ls_emailer_user_lists( $user_id = NULL ) {
 function ws_ls_emailer_lists_default_setting() {
 	$lists = [
 				'awards' 	=> true,
+				'notes'		=> true,
 				'birthdays' => true
 	];
 
@@ -664,12 +665,15 @@ function ws_ls_emailer_lists_default_setting() {
 /**
  * Fetch labels for email lists
  *
+ * Note: All new mailing lists must be added here
+ *
  * @return array
  */
 function ws_ls_emailer_lists_default_labels() {
 	$labels = [
-				'awards' 	=> __( 'Award emails', WE_LS_SLUG ),
-				'birthdays' => __( 'Birthday emails', WE_LS_SLUG )
+				'awards' 	=> __( 'Notifications about new awards', WE_LS_SLUG ),
+				'birthdays' => __( 'Birthday emails', WE_LS_SLUG ),
+				'notes' 	=> __( 'Notifications about new notes', WE_LS_SLUG )
 	];
 
 	return apply_filters( 'wlt-filter-email-lists-default-labels', $labels );

--- a/includes/email-manager.php
+++ b/includes/email-manager.php
@@ -584,3 +584,86 @@ function ws_ls_emailer_send( $to, $subject, $message, $placeholders = [] ) {
 
 	return false;
 }
+
+/**
+ * Has the user opted in for the given list?
+ *
+ * @param $list_name
+ * @param $user_id
+ * @return array
+ */
+function ws_ls_emailer_user_has_optedin( $list_name, $user_id = NULL ) {
+
+	if ( true === empty( $list_name ) ) {
+		return false;
+	}
+
+	$user_id = ( NULL === $user_id ) ? get_current_user_id() : $user_id;
+
+	// Ensure emails are enabled globally
+	if ( false === ws_ls_email_enabled() ) {
+		return false;
+	}
+
+	$lists = ws_ls_emailer_user_lists( $user_id );
+
+	// If we don't have a value in the user settings, we can assume we haven't saved their preferences 
+	// yet, or, we potentially have a new mailing list (so look up default)
+	if ( false === array_key_exists( $list_name, $lists ) ) {
+
+		$defaults = ws_ls_emailer_lists_default_setting();
+
+		// Invalid email list?
+		if ( ! array_key_exists( $list_name, $defaults ) ) {
+			return false;
+		}
+
+		$lists[ $list_name ] = $defaults[ $list_name ];
+
+	}
+
+	return ws_ls_to_bool( $lists[ $list_name ] );
+}
+
+/**
+ * Fetch user's email list preferences from settings
+ *
+ * @param $user_id
+ * @return array
+ */
+function ws_ls_emailer_user_lists( $user_id = NULL ) {
+
+	$user_id 	= ( NULL === $user_id ) ? get_current_user_id() : $user_id;
+
+	$lists 		= ws_ls_user_preferences_get( 'email_lists', $user_id );
+
+	return ( false === empty( $lists ) ) ? $lists : ws_ls_emailer_lists_default_setting();
+}
+
+/**
+ * Fetch default email list preferences
+ *
+ * Note: All new mailing lists must be added here
+ * 
+ * @return array
+ */
+function ws_ls_emailer_lists_default_setting() {
+	$lists = [
+				'birthday' => true
+	];
+
+	return apply_filters( 'wlt-filter-email-lists-default-settings', $lists );
+}
+
+/**
+ * Fetch labels for email lists
+ *
+ * @return array
+ */
+function ws_ls_emailer_lists_default_labels() {
+	$labels = [
+				'birthday' => __( 'Birthday emails', WE_LS_SLUG )
+	];
+
+	return apply_filters( 'wlt-filter-email-lists-default-labels', $labels );
+}

--- a/includes/email-manager.php
+++ b/includes/email-manager.php
@@ -637,7 +637,7 @@ function ws_ls_emailer_user_lists( $user_id = NULL ) {
 
 	$lists 		= ws_ls_user_preferences_get( 'email_lists', $user_id );
 
-	return ( false === empty( $lists ) ) ? $lists : ws_ls_emailer_lists_default_setting();
+	return ( false === empty( $lists ) ) ? json_decode( $lists, true ) : ws_ls_emailer_lists_default_setting();
 }
 
 /**
@@ -649,7 +649,7 @@ function ws_ls_emailer_user_lists( $user_id = NULL ) {
  */
 function ws_ls_emailer_lists_default_setting() {
 	$lists = [
-				'birthday' => true
+				'birthdays' => true
 	];
 
 	return apply_filters( 'wlt-filter-email-lists-default-settings', $lists );

--- a/includes/email-manager.php
+++ b/includes/email-manager.php
@@ -425,6 +425,11 @@ function ws_ls_emailer_replace_placeholders( $email, $placeholders ) {
 	if( false === empty( $email ) && false === empty( $placeholders ) ) {
 
 		foreach ( $placeholders as $key => $value ) {
+	
+			if ( NULL === $value ) {
+				$value = '';
+			}	
+
 			$email = str_replace('{' . $key . '}', $value, $email );
 		}
 
@@ -649,6 +654,7 @@ function ws_ls_emailer_user_lists( $user_id = NULL ) {
  */
 function ws_ls_emailer_lists_default_setting() {
 	$lists = [
+				'awards' 	=> true,
 				'birthdays' => true
 	];
 
@@ -662,6 +668,7 @@ function ws_ls_emailer_lists_default_setting() {
  */
 function ws_ls_emailer_lists_default_labels() {
 	$labels = [
+				'awards' 	=> __( 'Award emails', WE_LS_SLUG ),
 				'birthdays' => __( 'Birthday emails', WE_LS_SLUG )
 	];
 

--- a/includes/shortcode-wt.php
+++ b/includes/shortcode-wt.php
@@ -30,6 +30,7 @@ function ws_ls_shortcode_wt( $user_defined_arguments ) {
 												'hide-notifications' 		=> false,                        // Hide notifications part of form
 												'hide-photos' 				=> false,                       // Hide photos part of form
 												'hide-chart-overview' 		=> false,               	    // Hide chart on the overview tab
+												'hide-email-optout'     	=> false,						// Hide email opt in form
 												'hide-tab-awards' 		    => false,               	    // Hide Awards tab
 												'hide-tab-photos' 			=> false,                 	    // Hide Photos tab
 												'hide-tab-advanced' 		=> false,               	    // Hide Advanced tab (macroN, calories, etc)
@@ -230,7 +231,8 @@ function ws_ls_wt_form( $arguments = [] ) {
 	                                'user-id'               => $arguments[ 'user-id' ],
 	                                'redirect-url'          => $redirect_url,
 	                                'entry-id'              => ws_ls_querystring_value('ws-edit-entry', true, NULL ),
-	                                'hide-fields-photos'    => ws_ls_to_bool( $arguments[ 'hide-photos' ] ),
+	                                'hide-email-optout'     => false,
+									'hide-fields-photos'    => ws_ls_to_bool( $arguments[ 'hide-photos' ] ),
 	                                'hide-notes'            => ws_ls_to_bool( $arguments[ 'hide-notes' ] ),
 	                                'hide-title'            => true,
 	                                'hide-confirmation'     => true,
@@ -408,7 +410,7 @@ function ws_ls_wt_tab_home( $arguments = [] ) {
  * @return string
  */
 function ws_ls_tab_settings( $arguments = [] ) {
-
+	
 	$redirect_url =  ( true === $arguments[ 'kiosk-mode' ] ) ?
 						add_query_arg( [    'wt-user-id'            => $arguments[ 'user-id' ],
 											'user-preference-saved' => 'true',
@@ -432,10 +434,11 @@ function ws_ls_tab_settings( $arguments = [] ) {
 	}
 
 	if( true === ws_ls_user_preferences_is_enabled() ) {
-
+		
 		$settings = ws_ls_user_preferences_form( [  'user-id'           => $arguments[ 'user-id' ],
 		                                            'uikit'             => true,
-		                                            'show-delete-data'  => false,
+													'show-delete-data'  => false,
+													'hide-email-optout' => $arguments[ 'hide-email-optout' ],
 		                                            'kiosk-mode'        => $arguments[ 'kiosk-mode' ],
 		                                            'redirect-url'      => $redirect_url
 		]);

--- a/pro-features/email-notifications.php
+++ b/pro-features/email-notifications.php
@@ -16,7 +16,7 @@ function ws_ls_email_enabled() {
 }
 
 /**
- * Send email notifications for weight / meta updates as wel as targets
+ * Send email notifications for weight / meta updates as well as targets
  * @param $type
  * @param $weight_data
  */

--- a/pro-features/functions.php
+++ b/pro-features/functions.php
@@ -357,6 +357,32 @@ function ws_ls_get_email_link( $user_id, $include_brackets = false ) {
 }
 
 /**
+ * Return a simple object to represent user data
+ *
+ * @param $user_id
+ * @return array
+ */
+function ws_ls_simple_user_object( $user_id = NULL ) {
+
+	$user_id = ( NULL === $user_id ) ? get_current_user_id() : $user_id;
+	
+	$user_data = get_userdata( $user_id );
+
+	if ( false == $user_data) {
+		return [];
+	}
+
+	$data = [];
+
+	$data[ 'user-id' ]				= $user_id;
+	$data[ 'email' ]				= $user_data->user_email;
+	$data[ 'display-name' ]    		= ws_ls_user_display_name( $user_id );
+	$data[ 'url-user-profile' ]     = ws_ls_get_link_to_user_profile( $user_id, NULL, false );
+
+	return $data;
+}
+
+/**
  * Return an array of supported genders
  *
  * @return array

--- a/pro-features/plus/awards/hooks.php
+++ b/pro-features/plus/awards/hooks.php
@@ -304,6 +304,11 @@ function ws_ls_awards_send_email( $weight_object, $award, $info ) {
         return;
     }
 
+	// Has user opted in to award notifications
+	if ( false === ws_ls_emailer_user_has_optedin( 'awards', $info['user-id'] ) ) {
+		return;
+	}
+
     $email_template = ws_ls_emailer_get( 'email-award ');
 
     if ( false === empty( $email_template ) ) {

--- a/pro-features/plus/messaging/db.php
+++ b/pro-features/plus/messaging/db.php
@@ -106,6 +106,8 @@ function ws_ls_messaging_db_add( $to, $from, $message, $is_note = false, $visibl
 	                'visible_to_user'   => $visible_to_user,
 	                'notification'      => $notification ];
 
+	do_action( 'wlt-hook-data-new-note', $data );
+
 	$formats    = [ '%d', '%d', '%s', '%d', '%d' ];
 
 	$key                    = ( true === $is_note ) ? 'note' : 'message';

--- a/pro-features/plus/messaging/hooks.php
+++ b/pro-features/plus/messaging/hooks.php
@@ -17,7 +17,8 @@ function ws_ls_note_ajax_add() {
 		return 0;
 	}
 
-	if ( true === ws_ls_post_value_to_bool('send-email' ) ) {
+	if ( true === ws_ls_post_value_to_bool('send-email', $user_id) &&
+			true === ws_ls_emailer_user_has_optedin( 'notes', ) ) {
 
 		$email_template = ws_ls_emailer_get( 'note-added' );
 

--- a/pro-features/user-birthdays.php
+++ b/pro-features/user-birthdays.php
@@ -101,19 +101,26 @@
 
 	    $birthday_boys_or_girls = ws_ls_birthdays_identify();
 
-	    $i = 0;
+	    $sent       = 0;
+        $opted_out  = 0;
 
 	    if ( false === empty( $birthday_boys_or_girls ) ) {
 
 	    	foreach ( $birthday_boys_or_girls as $celebrate ) {
 
+                if ( ! ws_ls_emailer_user_has_optedin( 'birthdays', $celebrate[ 'user_id' ] ) ) {
+                    $opted_out++;
+                    continue;
+                }
+
 	    		if ( true === ws_ls_birthdays_send_email( $celebrate[ 'user_id' ] ) ) {
-				    $i++;
+				    $sent++;
 			    }
 		    }
 	    }
 
-	    ws_ls_log_add( 'birthdays', sprintf( 'Birthday emails sent today: %d', $i ) );
+	    ws_ls_log_add( 'birthdays', sprintf( 'Birthday emails sent today: %d', $sent ) );
+        ws_ls_log_add( 'birthdays', sprintf( 'Number of users opted out of today\'s birthday email: %d', $opted_out ) );
     }
 	add_action('weight_loss_tracker_daily', 'ws_ls_birthdays_send_daily_emails');
 

--- a/pro-features/user-preferences.php
+++ b/pro-features/user-preferences.php
@@ -27,6 +27,7 @@ function ws_ls_user_preferences_form( $user_defined_arguments ) {
                                     'hide-activity-level'   => false,
                                     'hide-preferences'      => false,
                                     'hide-extras'           => false,
+									'hide-email-optout'     => false,
                                     'hide-titles'           => false,
                                     'user-id'               => get_current_user_id(),
                                     'uikit'                 => false,
@@ -141,6 +142,16 @@ function ws_ls_user_preferences_form( $user_defined_arguments ) {
 			                                            'selected'  => ( true === ws_ls_setting( 'use-us-dates', $user_id ) ) ? 'true' : 'false' ] );
 
 		}
+
+		if ( false === ws_ls_to_bool( $arguments[ 'hide-email-optout' ] ) ) {
+			$html_output .=  sprintf( '<div class="ws-ls-form-row ykuk-width-1-1">
+											<h3>%s</h3>
+											<p class="ws-ls-hide-if-admin">%s</p>
+										</div>', __( 'Email notifications', WE_LS_SLUG ),
+										__( 'Select the email notifications that you would like to receive:', WE_LS_SLUG )
+									);
+			$html_output .=  ws_ls_emailer_optout_form();
+		}	
 
 		if ( true !== $arguments[ 'disable-save' ] ) {
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aliakro
 Tags: weight,tracker,chart,history,macronutrient
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 10.8.4
+Stable tag: 10.9
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -148,11 +148,11 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 == Upgrade Notice ==
 
-10.8: New components for displaying custom field data on [wt] shortcode.
+10.9: New user settings for opting in and out of email notifications.
 
 == Changelog ==
 
-= 10.* = 
+= 10.9 = 
 
 * New feature: Web Hooks: Data can now be fired to endpoints for new notes, see new setting "Send data for new notes".
 * New feature: Users can now opt out of emails from Weight Tracker via the user preferences [wt-user-settings] or [wt].

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,11 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 == Changelog ==
 
+= 10.* = 
+
+* New feature:
+* Improvement: Moved "Birthday emails" setting to "Emails & Notifications" tab within Weight Tracker settings.
+
 = 10.8.4 = 
 
 * Maintenance: Updated code around Gravity Forms to deal with PHP8.2 and false being a possible return from getLastErrors().

--- a/readme.txt
+++ b/readme.txt
@@ -154,6 +154,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 = 10.* = 
 
+* New feature: Web Hooks: Data can now be fired to endpoints for new notes, see new setting "Send data for new notes".
 * New feature: Users can now opt out of emails from Weight Tracker via the user preferences [wt-user-settings] or [wt].
 * New feature: Admin can now manage user's opt out preferences when editing a user's settings.
 * New feature: Users can now opt out of birthday emails. 

--- a/readme.txt
+++ b/readme.txt
@@ -154,7 +154,8 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 
 = 10.* = 
 
-* New feature:
+* New feature: Users can now opt out of emails from Weight Tracker via the user preferences [wt-user-settings] or [wt].
+* New feature: Users can now opt out of birthday emails. 
 * Improvement: Moved "Birthday emails" setting to "Emails & Notifications" tab within Weight Tracker settings.
 
 = 10.8.4 = 

--- a/readme.txt
+++ b/readme.txt
@@ -158,6 +158,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 * New feature: Admin can now manage user's opt out preferences when editing a user's settings.
 * New feature: Users can now opt out of birthday emails. 
 * New feature: Users can now opt out of new award emails. 
+* New feature: Users can now opt out of new note emails. 
 * Improvement: Added "hide-email-optout" argument to [wt-user-settings] and [wt] shortcodes to hide the email opt out form.
 * Improvement: Moved "Birthday emails" setting to "Emails & Notifications" tab within Weight Tracker settings.
 

--- a/readme.txt
+++ b/readme.txt
@@ -155,7 +155,9 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 = 10.* = 
 
 * New feature: Users can now opt out of emails from Weight Tracker via the user preferences [wt-user-settings] or [wt].
+* New feature: Admin can now manage user's opt out preferences when editing a user's settings.
 * New feature: Users can now opt out of birthday emails. 
+* Improvement: Added "hide-email-optout" argument to [wt-user-settings] and [wt] shortcodes to hide the email opt out form.
 * Improvement: Moved "Birthday emails" setting to "Emails & Notifications" tab within Weight Tracker settings.
 
 = 10.8.4 = 

--- a/readme.txt
+++ b/readme.txt
@@ -157,6 +157,7 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 * New feature: Users can now opt out of emails from Weight Tracker via the user preferences [wt-user-settings] or [wt].
 * New feature: Admin can now manage user's opt out preferences when editing a user's settings.
 * New feature: Users can now opt out of birthday emails. 
+* New feature: Users can now opt out of new award emails. 
 * Improvement: Added "hide-email-optout" argument to [wt-user-settings] and [wt] shortcodes to hide the email opt out form.
 * Improvement: Moved "Birthday emails" setting to "Emails & Notifications" tab within Weight Tracker settings.
 

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die('Jog on!');
 /**
  * Plugin Name:         Weight Tracker
  * Description:         Allow your users to track their weight, body measurements, photos and other pieces of custom data. Display in charts, tables, shortcodes and widgets. Manage their data, issue awards, email notifications, etc! Provide advanced data on Body Mass Index (BMI), Basal Metabolic Rate (BMR), Calorie intake, Harris Benedict Formula, Macronutrients Calculator and more.
- * Version:             10.8.4
+ * Version:             10.9
  * Requires at least:   6.0
  * Tested up to:		6.5
  * Requires PHP:        7.4
@@ -18,7 +18,7 @@ defined('ABSPATH') or die('Jog on!');
  */
 
 define( 'WS_LS_ABSPATH', plugin_dir_path( __FILE__ ) );
-define( 'WE_LS_CURRENT_VERSION', '10.8.4aa' );
+define( 'WE_LS_CURRENT_VERSION', '10.9' );
 define( 'WE_LS_TITLE', 'Weight Tracker' );
 define( 'WE_LS_SLUG', 'weight-loss-tracker' );
 define( 'WE_LS_LICENSE_TYPES_URL', 'https://docs.yeken.uk/features.html' );

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -18,7 +18,7 @@ defined('ABSPATH') or die('Jog on!');
  */
 
 define( 'WS_LS_ABSPATH', plugin_dir_path( __FILE__ ) );
-define( 'WE_LS_CURRENT_VERSION', '10.8.4' );
+define( 'WE_LS_CURRENT_VERSION', '10.8.4aa' );
 define( 'WE_LS_TITLE', 'Weight Tracker' );
 define( 'WE_LS_SLUG', 'weight-loss-tracker' );
 define( 'WE_LS_LICENSE_TYPES_URL', 'https://docs.yeken.uk/features.html' );
@@ -181,3 +181,16 @@ function ws_ls_load_textdomain() {
 	load_plugin_textdomain( WE_LS_SLUG, false, dirname( plugin_basename( __FILE__ )  ) . '/includes/languages/' );
 }
 add_action('plugins_loaded', 'ws_ls_load_textdomain');
+
+
+
+function test() {
+
+	$user_id = 1;
+
+	$s = ws_ls_emailer_user_lists( $user_id );
+	print_r( $s);
+	var_dump(ws_ls_emailer_user_has_optedin( 'birthdays', $user_id ));
+	die;
+}
+// add_action( 'init', 'test' );


### PR DESCRIPTION
* New feature: Web Hooks: Data can now be fired to endpoints for new notes, see new setting "Send data for new notes".
* New feature: Users can now opt out of emails from Weight Tracker via the user preferences [wt-user-settings] or [wt].
* New feature: Admin can now manage user's opt out preferences when editing a user's settings.
* New feature: Users can now opt out of birthday emails. 
* New feature: Users can now opt out of new award emails. 
* New feature: Users can now opt out of new note emails. 
* Improvement: Added "hide-email-optout" argument to [wt-user-settings] and [wt] shortcodes to hide the email opt out form.
* Improvement: Moved "Birthday emails" setting to "Emails & Notifications" tab within Weight Tracker settings.
