### PR TITLE
10.18

### DIFF
--- a/includes/admin-pages/user-data/data-add-edit-entry.php
+++ b/includes/admin-pages/user-data/data-add-edit-entry.php
@@ -40,7 +40,7 @@ function ws_ls_admin_page_data_add_edit() {
 						<div class="postbox">
 							<h2><span><?php echo esc_html__('Add / Edit an entry', WE_LS_SLUG); ?></span></h2>
 							<div class="inside">
-								<?php
+								<?php 
 	                                if ( true === WS_LS_IS_PRO ) {
 
 		                                echo ws_ls_form_weight( [    'user-id'              => $user_id,
@@ -49,6 +49,31 @@ function ws_ls_admin_page_data_add_edit() {
 		                                                             'hide-login-message'   => true,
 																	 'weight-mandatory'		=> false
 		                                ] );
+
+										// Allow to manually fire web hook again
+										if ( true === ws_ls_webhooks_enabled() ) {
+
+											$link = ws_ls_get_url();
+
+											$link = add_query_arg( [ 'webhook-entry-id' => $entry_id, 'webhook-user-id' => $user_id ] );
+										
+											printf( '	<br />
+														<hr />
+														<h3>%1$s<h3>
+														<a class="button-secondary" href="%2$s"><i class="fa fa-arrow-right"></i> %3$s</a>',  
+														esc_html__( 'Web Hooks', WE_LS_SLUG ),
+														esc_url( $link ), 
+														esc_html__( 'Re-send to endpoint(s)', WE_LS_SLUG ) );		
+
+											$entry_id 	= ws_ls_querystring_value( 'webhook-entry-id' );		
+											$user_id 	= ws_ls_querystring_value( 'webhook-user-id' );		
+
+											if ( false === empty( $user_id ) && 
+													false === empty( $entry_id ) ) {
+														ws_ls_webhooks_manually_fire_weight( $user_id, $entry_id );
+														printf( '<p>%s</p>', esc_html__( 'Sent!', WE_LS_SLUG ) );
+											}
+										}
 
 	                                } else {
 	                                    echo sprintf( '<p>%s</p>', esc_html__('A Pro license is required to add / edit a weight entry.', WE_LS_SLUG) );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -873,7 +873,7 @@ function ws_ls_get_url( $base_64_encode = false ) {
 
 	$current_url = sanitize_url( $current_url );
 	
-	$current_url = remove_query_arg( [ 'group-id', 'removedata', 'removed' ] , $current_url );
+	$current_url = remove_query_arg( [ 'group-id', 'removedata', 'removed', 'webhook-entry-id', 'webhook-user-id' ] , $current_url );
 
 	return ( true === $base_64_encode ) ? base64_encode( $current_url ) : $current_url;
 }

--- a/pro-features/web-hooks.php
+++ b/pro-features/web-hooks.php
@@ -145,6 +145,24 @@ function ws_ls_webhooks_weight_target( $type, $entry ) {
 add_action( 'wlt-hook-data-added-edited', 'ws_ls_webhooks_weight_target', 10, 2 );
 
 /**
+ * Manually fire an a web hook for this weight entry
+ */
+function ws_ls_webhooks_manually_fire_weight( $user_id, $entry_id ) {
+
+	if ( true === empty( $user_id ) ) {
+		return;
+	}
+
+	if ( true === empty( $entry_id ) ) {
+		return;
+	}
+
+	$entry = ws_ls_entry_get( [ 'user-id' => $user_id, 'id' => $entry_id, 'meta' => true ] );
+
+	ws_ls_webhooks_weight_target( [ 'type' => 'weight', 'mode' => 'resend' ], $entry );
+}
+
+/**
  * Listen out for new note hooks
  * @param $note
  */

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aliakro
 Tags: weight,tracker,chart,history,macronutrient
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 10.17
+Stable tag: 10.18
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -169,6 +169,10 @@ Measurements are created using Custom Fields. You can therefore specify the unit
 10.17: New feature: Expanded [wt-if] shortcodes to include comparison modes.
 
 == Changelog ==
+
+= 10.18 =
+
+* New feature: Added "Re-send to Endpoint(s)" button to "Edit Entry" screen within WP Dashboard. When pressed, the entry as currently seen, is re-fired to all webhook endpoints.
 
 = 10.17 =
 

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die('Jog on!');
 /**
  * Plugin Name:         Weight Tracker
  * Description:         Allow your users to track their weight, body measurements, photos and other pieces of custom data. Display in charts, tables, shortcodes and widgets. Manage their data, issue awards, email notifications, etc! Provide advanced data on Body Mass Index (BMI), Basal Metabolic Rate (BMR), Calorie intake, Harris Benedict Formula, Macronutrients Calculator and more.
- * Version:             10.17
+ * Version:             10.18
  * Requires at least:   6.0
  * Tested up to:		6.5
  * Requires PHP:        7.4
@@ -17,7 +17,7 @@ defined('ABSPATH') or die('Jog on!');
  * Domain Path:         /includes/languages
  */
 
-define( 'WE_LS_CURRENT_VERSION', '10.17' );
+define( 'WE_LS_CURRENT_VERSION', '10.18' );
 define( 'WS_LS_ABSPATH', plugin_dir_path( __FILE__ ) );
 define( 'WS_LS_BASE_URL', plugin_dir_url( __FILE__ ) );
 define( 'WE_LS_TITLE', 'Weight Tracker' );


### PR DESCRIPTION
* New feature: Added "Re-send to Endpoint(s)" button to "Edit Entry" screen within WP Dashboard. When pressed, the entry as currently seen, is re-fired to all webhook endpoints.